### PR TITLE
Prevent tcp pair form throwing exceptions in the destructor

### DIFF
--- a/gloo/rendezvous/context.cc
+++ b/gloo/rendezvous/context.cc
@@ -33,8 +33,7 @@ void Context::connectFullMesh(
       continue;
     }
 
-    auto pair = dev->createPair();
-    pairs[i] = std::move(pair);
+    pairs[i] = dev->createPair();
 
     // Store address for pair for this rank
     std::ostringstream key;

--- a/gloo/transport/tcp/pair.h
+++ b/gloo/transport/tcp/pair.h
@@ -115,7 +115,7 @@ class Pair : public ::gloo::transport::Pair {
   void handleConnecting();
   void handleConnected();
 
-  void changeState(state state);
+  void changeState(state state, bool enforceConnected = true);
 };
 
 } // namespace tcp


### PR DESCRIPTION
Previously when e.g. a Redis connection/store (e.g. protected mode) failed, it would throw an exception that would cause the pair to be destructed, and it would throw another one because it wasn't in the connected state yet. It's quite annoying because it shadows the original problem.