### PR TITLE
Execute benchmark through mpirun

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -36,6 +36,17 @@ Suppress this warning with -DUSE_IBVERBS=OFF")
   endif()
 endif()
 
+if(USE_MPI)
+  find_package(MPI)
+  if(MPI_C_FOUND)
+    message(STATUS "MPI include path: " ${MPI_CXX_INCLUDE_PATH})
+    message(STATUS "MPI libraries: " ${MPI_CXX_LIBRARIES})
+    include_directories(SYSTEM ${MPI_CXX_INCLUDE_PATH})
+    list(APPEND gloo_DEPENDENCY_LIBS ${MPI_CXX_LIBRARIES})
+    add_definitions(-DGLOO_USE_MPI=1)
+  endif()
+endif()
+
 # Make sure we can find googletest if building the tests
 if(BUILD_TEST)
   if (EXISTS "${PROJECT_SOURCE_DIR}/third-party/googletest")

--- a/gloo/CMakeLists.txt
+++ b/gloo/CMakeLists.txt
@@ -4,22 +4,17 @@ set(GLOO_SRCS)
 # GLOO_HDRS is the list of header files that we need to install.
 set(GLOO_HDRS)
 
-# GLOO_TEST_SRCS is the list of test sources.
-set(GLOO_TEST_SRCS)
-
-# GLOO_BENCHMARK_SRCS is the list of benchmark sources.
-set(GLOO_TEST_SRCS)
-
 # Compiled sources in root directory
 list(APPEND GLOO_SRCS
     "${CMAKE_CURRENT_SOURCE_DIR}/algorithm.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/context.cc"
-)
+    )
 
 file(GLOB GLOO_ROOT_HDRS "*.h")
 list(APPEND GLOO_HDRS ${GLOO_ROOT_HDRS})
 
 add_subdirectory(common)
+add_subdirectory(mpi)
 add_subdirectory(rendezvous)
 add_subdirectory(transport)
 
@@ -44,12 +39,8 @@ endforeach()
 
 if(BUILD_TEST)
 add_subdirectory(test)
-add_executable(gloo_test ${GLOO_TEST_SRCS})
-target_link_libraries(gloo_test gloo gtest)
 endif()
 
 if(BUILD_BENCHMARK)
 add_subdirectory(benchmark)
-add_executable(gloo_benchmark ${GLOO_BENCHMARK_SRCS})
-target_link_libraries(gloo_benchmark gloo)
 endif()

--- a/gloo/benchmark/CMakeLists.txt
+++ b/gloo/benchmark/CMakeLists.txt
@@ -1,6 +1,13 @@
+add_definitions(-DBENCHMARK_TCP=1)
+if(USE_IBVERBS)
+  add_definitions(-DBENCHMARK_IBVERBS=1)
+endif()
+
 set(GLOO_BENCHMARK_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/main.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/options.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/runner.cc"
-  PARENT_SCOPE
   )
+
+add_executable(gloo_benchmark ${GLOO_BENCHMARK_SRCS})
+target_link_libraries(gloo_benchmark gloo)

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -190,6 +190,11 @@ struct options parseOptions(int argc, char** argv) {
     }
   }
 
+#ifdef GLOO_USE_MPI
+  // Use MPI if started through mpirun
+  result.mpi = (getenv("OMPI_UNIVERSE_SIZE") != nullptr);
+#endif
+
   if (result.busyPoll && !result.sync) {
     fprintf(stderr, "%s: busy poll can only be used with sync mode\n", argv[0]);
     usage(EXIT_FAILURE, argv[0]);

--- a/gloo/benchmark/options.h
+++ b/gloo/benchmark/options.h
@@ -23,6 +23,10 @@ struct options {
   int redisPort = 6379;
   std::string prefix = "prefix";
 
+#ifdef GLOO_USE_MPI
+  bool mpi = false;
+#endif
+
   // Transport
   std::string transport;
   std::string ibverbsDevice = "mlx5_0";

--- a/gloo/benchmark/runner.h
+++ b/gloo/benchmark/runner.h
@@ -29,6 +29,7 @@ class Runner {
      std::shared_ptr<::gloo::Context>&)>;
 
   explicit Runner(const options& options);
+  ~Runner();
 
   void run(BenchmarkFn& fn);
   void run(BenchmarkFn& fn, int n);

--- a/gloo/mpi/CMakeLists.txt
+++ b/gloo/mpi/CMakeLists.txt
@@ -1,0 +1,13 @@
+if(USE_MPI)
+  set(GLOO_MPI_SRCS
+    "${CMAKE_CURRENT_SOURCE_DIR}/context.cc"
+    )
+  set(GLOO_MPI_HDRS
+    "${CMAKE_CURRENT_SOURCE_DIR}/context.h"
+    )
+  list(APPEND GLOO_SRCS ${GLOO_MPI_SRCS})
+  list(APPEND GLOO_HDRS ${GLOO_MPI_HDRS})
+endif()
+
+set(GLOO_SRCS ${GLOO_SRCS} PARENT_SCOPE)
+set(GLOO_HDRS ${GLOO_HDRS} PARENT_SCOPE)

--- a/gloo/test/CMakeLists.txt
+++ b/gloo/test/CMakeLists.txt
@@ -3,5 +3,7 @@ set(GLOO_TEST_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/barrier_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/broadcast_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/main.cc"
-  PARENT_SCOPE
   )
+
+add_executable(gloo_test ${GLOO_TEST_SRCS})
+target_link_libraries(gloo_test gloo gtest)


### PR DESCRIPTION
This change includes CMake changes to compile the MPI assets when the USE_MPI flag is enabled. If so, the benchmark tool can now be launched through mpirun.

Includes the changes done in #11.