### PR TITLE
Add explicit dependency on pthreads

### DIFF
--- a/gloo/CMakeLists.txt
+++ b/gloo/CMakeLists.txt
@@ -18,6 +18,9 @@ add_subdirectory(mpi)
 add_subdirectory(rendezvous)
 add_subdirectory(transport)
 
+# Depend on pthreads for transport device threads
+list(APPEND gloo_DEPENDENCY_LIBS pthread)
+
 # Enable the following to get a list of source files
 if(FALSE)
   message(STATUS "Sources: ")


### PR DESCRIPTION
Got linker errors on Ubuntu 16.04 (not on 14.04).
Adding the pthreads dependency explicitly fixes it.