### PR TITLE
MPI: Duplicate MPI_Comm and allreduce maxLength as MPI_ UNSIGNED_LONG.

### DIFF
--- a/gloo/mpi/context.cc
+++ b/gloo/mpi/context.cc
@@ -18,26 +18,29 @@
 namespace gloo {
 namespace mpi {
 
-static int MPICommSize(MPI_Comm comm) {
+static int MPICommSize(const MPI_Comm &comm) {
   int comm_size;
   auto error = MPI_Comm_size(comm, &comm_size);
   GLOO_ENFORCE(error == MPI_SUCCESS, "MPI_Comm_size: ", error);
   return comm_size;
 }
 
-static int MPICommRank(MPI_Comm comm) {
+static int MPICommRank(const MPI_Comm &comm) {
   int comm_rank;
   auto error = MPI_Comm_rank(comm, &comm_rank);
   GLOO_ENFORCE(error == MPI_SUCCESS, "MPI_Comm_rank: ", error);
   return comm_rank;
 }
 
-Context::Context(MPI_Comm comm)
+Context::Context(const MPI_Comm &comm)
     : ::gloo::Context(MPICommRank(comm), MPICommSize(comm)),
-      comm_(comm) {
+      comm_() {
+  auto error = MPI_Comm_dup(comm, &comm_);
+  GLOO_ENFORCE(error == MPI_SUCCESS, "MPI_Comm_dup: ", error);
 }
 
 Context::~Context() {
+  MPI_Comm_free(&comm_);
 }
 
 void Context::connectFullMesh(std::shared_ptr<transport::Device>& dev) {
@@ -63,7 +66,7 @@ void Context::connectFullMesh(std::shared_ptr<transport::Device>& dev) {
 
   // Agree on maximum length so we can prepare buffers
   rv = MPI_Allreduce(
-    &maxLength, &maxLength, 1, MPI_INT, MPI_MAX, comm_);
+    &maxLength, &maxLength, 1, MPI_UNSIGNED_LONG, MPI_MAX, comm_);
   if (rv != MPI_SUCCESS) {
     GLOO_THROW_IO_EXCEPTION("MPI_Allreduce: ", rv);
   }

--- a/gloo/mpi/context.cc
+++ b/gloo/mpi/context.cc
@@ -18,23 +18,22 @@
 namespace gloo {
 namespace mpi {
 
-static int MPICommSize(const MPI_Comm &comm) {
+static int MPICommSize(const MPI_Comm& comm) {
   int comm_size;
   auto error = MPI_Comm_size(comm, &comm_size);
   GLOO_ENFORCE(error == MPI_SUCCESS, "MPI_Comm_size: ", error);
   return comm_size;
 }
 
-static int MPICommRank(const MPI_Comm &comm) {
+static int MPICommRank(const MPI_Comm& comm) {
   int comm_rank;
   auto error = MPI_Comm_rank(comm, &comm_rank);
   GLOO_ENFORCE(error == MPI_SUCCESS, "MPI_Comm_rank: ", error);
   return comm_rank;
 }
 
-Context::Context(const MPI_Comm &comm)
-    : ::gloo::Context(MPICommRank(comm), MPICommSize(comm)),
-      comm_() {
+Context::Context(const MPI_Comm& comm)
+    : ::gloo::Context(MPICommRank(comm), MPICommSize(comm)) {
   auto error = MPI_Comm_dup(comm, &comm_);
   GLOO_ENFORCE(error == MPI_SUCCESS, "MPI_Comm_dup: ", error);
 }

--- a/gloo/mpi/context.h
+++ b/gloo/mpi/context.h
@@ -19,7 +19,7 @@ namespace mpi {
 
 class Context : public ::gloo::Context {
  public:
-  explicit Context(const MPI_Comm &comm);
+  explicit Context(const MPI_Comm& comm);
   virtual ~Context();
 
   void connectFullMesh(std::shared_ptr<transport::Device>& dev);

--- a/gloo/mpi/context.h
+++ b/gloo/mpi/context.h
@@ -19,7 +19,7 @@ namespace mpi {
 
 class Context : public ::gloo::Context {
  public:
-  explicit Context(MPI_Comm comm);
+  explicit Context(const MPI_Comm &comm);
   virtual ~Context();
 
   void connectFullMesh(std::shared_ptr<transport::Device>& dev);


### PR DESCRIPTION
Some small MPI-related changes:
1) Instead of making an object copy of the MPI_Comm, call MPI_Comm_dup;
because the (passed-in) communicator is used later via the call to
connectFullMesh this guarantees that the communicator will not have been
freed by user before connectFullMesh is called.

2) Allreduce for maxLength is done on an unsigned long type; use the
corresponding MPI type.