### PR TITLE
Include common/linux.{h,cc} in CMake build

### DIFF
--- a/gloo/common/CMakeLists.txt
+++ b/gloo/common/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(GLOO_COMMON_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/linux.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/logging.cc"
   )
 
 set(GLOO_COMMON_HDRS
   "${CMAKE_CURRENT_SOURCE_DIR}/error.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/linux.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/logging.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/string.h"
   )


### PR DESCRIPTION
Forgot to include these in a previous commit.