### PR TITLE
Generate config.h file with compilation options

### DIFF
--- a/gloo/CMakeLists.txt
+++ b/gloo/CMakeLists.txt
@@ -52,6 +52,16 @@ if(FALSE)
   endforeach()
 endif()
 
+# Write configuration header.
+# Set variables so macros have GLOO_ prefix.
+set(GLOO_USE_CUDA ${USE_CUDA})
+set(GLOO_USE_REDIS ${USE_REDIS})
+set(GLOO_USE_IBVERBS ${USE_IBVERBS})
+configure_file(config.h.in config.h)
+
+# Prepend include path so that generated config.h is picked up.
+include_directories(BEFORE ${CMAKE_BINARY_DIR})
+
 add_library(gloo ${GLOO_STATIC_OR_SHARED} ${GLOO_SRCS})
 target_link_libraries(gloo ${gloo_DEPENDENCY_LIBS})
 if(USE_CUDA)
@@ -77,6 +87,8 @@ if(GLOO_INSTALL)
   if(USE_CUDA)
     install(TARGETS gloo_cuda DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
   endif()
+  install(FILES ${CMAKE_BINARY_DIR}/gloo/config.h
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/gloo)
   foreach(HEADER ${GLOO_HDRS})
     string(REGEX MATCH "(.*)[/\\]" DIR ${HEADER})
     string(REGEX REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "gloo" DIR ${DIR})

--- a/gloo/config.h
+++ b/gloo/config.h
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once

--- a/gloo/config.h.in
+++ b/gloo/config.h.in
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#cmakedefine01 GLOO_USE_CUDA
+#cmakedefine01 GLOO_USE_REDIS
+#cmakedefine01 GLOO_USE_IBVERBS

--- a/gloo/cuda.h
+++ b/gloo/cuda.h
@@ -16,7 +16,13 @@
 #include <cuda_runtime.h>
 
 #include "gloo/algorithm.h"
+#include "gloo/config.h"
 #include "gloo/common/logging.h"
+
+// Check that configuration header was properly generated
+#if !GLOO_USE_CUDA
+#error "Expected GLOO_USE_CUDA to be defined"
+#endif
 
 namespace gloo {
 

--- a/gloo/rendezvous/redis_store.h
+++ b/gloo/rendezvous/redis_store.h
@@ -18,7 +18,13 @@
 #include <hiredis.h>
 #endif
 
+#include "gloo/config.h"
 #include "gloo/rendezvous/store.h"
+
+// Check that configuration header was properly generated
+#if !GLOO_USE_REDIS
+#error "Expected GLOO_USE_REDIS to be defined"
+#endif
 
 namespace gloo {
 namespace rendezvous {

--- a/gloo/transport/ibverbs/device.h
+++ b/gloo/transport/ibverbs/device.h
@@ -14,7 +14,13 @@
 
 #include <infiniband/verbs.h>
 
+#include "gloo/config.h"
 #include "gloo/transport/device.h"
+
+// Check that configuration header was properly generated
+#if !GLOO_USE_IBVERBS
+#error "Expected GLOO_USE_IBVERBS to be defined"
+#endif
 
 namespace gloo {
 namespace transport {


### PR DESCRIPTION
This file can then be used by downstream code to figure out what Gloo
features it can support (e.g. ibverbs transport or not).