### PR TITLE
Fix build when included by another project

### DIFF
--- a/gloo/CMakeLists.txt
+++ b/gloo/CMakeLists.txt
@@ -61,7 +61,8 @@ set(GLOO_USE_IBVERBS ${USE_IBVERBS})
 configure_file(config.h.in config.h)
 
 # Prepend include path so that generated config.h is picked up.
-include_directories(BEFORE ${CMAKE_BINARY_DIR})
+# Note that it is included as "gloo/config.h" to add parent directory.
+include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/..)
 
 add_library(gloo ${GLOO_STATIC_OR_SHARED} ${GLOO_SRCS})
 target_link_libraries(gloo ${gloo_DEPENDENCY_LIBS})


### PR DESCRIPTION
The CMake variable CMAKE_BINARY_DIR points to the top level build
directory. For standalone Gloo builds this path lets files include the
generated file "gloo/config.h". When Gloo is included as project, this
variable points to a different path and "gloo/config.h" cannot be
resolved. Fix is to build a path from CMAKE_CURRENT_BINARY_DIR.