### PR TITLE
Fix PCI bus ID lookup for InfiniBand adapters

### DIFF
--- a/gloo/common/linux.cc
+++ b/gloo/common/linux.cc
@@ -83,10 +83,10 @@ static unsigned int pciGetClass(const std::string& id) {
   return pciClass;
 }
 
-std::vector<std::string> pciDevices(int pciClass) {
+std::vector<std::string> pciDevices(PCIClassMatch match) {
   std::vector<std::string> devices;
   for (const auto& device : listDir(kSysfsPath)) {
-    if (pciClass != pciGetClass(device)) {
+    if (match.value != (pciGetClass(device) & match.mask)) {
       continue;
     }
 

--- a/gloo/common/linux.h
+++ b/gloo/common/linux.h
@@ -17,10 +17,18 @@ namespace gloo {
 
 const std::set<std::string>& kernelModules();
 
-const int kPCIClass3D = 0x030200;
-const int kPCIClassNetwork = 0x020000;
+struct PCIClassMatch {
+  int value;
+  int mask;
+};
 
-std::vector<std::string> pciDevices(int pciBusID);
+// Matches 03 (Display controller), 02 (3D controller)
+const auto kPCIClass3D = PCIClassMatch{0x030200, 0xffff00};
+
+// Matches 02 (Network controller), both Ethernet (00) and InfiniBand (07)
+const auto kPCIClassNetwork = PCIClassMatch{0x020000, 0xff0000};
+
+std::vector<std::string> pciDevices(PCIClassMatch);
 
 int pciDistance(const std::string& a, const std::string& b);
 


### PR DESCRIPTION
These adapters use the 02 class, 07 subclass. Ethernet adapters use
02 class, 00 subclass. To catch both, the device list routine masks
the relevant part of the bus ID when matching.