### PR TITLE
Reduce onto GPU closest to networking adapter when using GPUDirect

### DIFF
--- a/gloo/context.cc
+++ b/gloo/context.cc
@@ -25,6 +25,11 @@ Context::Context(int rank, int size)
 Context::~Context() {
 }
 
+std::shared_ptr<transport::Device>& Context::getDevice() {
+  GLOO_ENFORCE(device_, "Device not set!");
+  return device_;
+}
+
 std::unique_ptr<transport::Pair>& Context::getPair(int i) {
   return pairs_.at(i);
 }

--- a/gloo/context.h
+++ b/gloo/context.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <vector>
 
+#include "gloo/transport/device.h"
 #include "gloo/transport/pair.h"
 
 namespace gloo {
@@ -24,11 +25,14 @@ class Context {
   const int rank;
   const int size;
 
+  std::shared_ptr<transport::Device>& getDevice();
+
   std::unique_ptr<transport::Pair>& getPair(int i);
 
   int nextSlot(int numToSkip = 1);
 
  protected:
+  std::shared_ptr<transport::Device> device_;
   std::vector<std::unique_ptr<transport::Pair>> pairs_;
   int slot_;
 };

--- a/gloo/cuda_allreduce_ring.cc
+++ b/gloo/cuda_allreduce_ring.cc
@@ -143,9 +143,11 @@ template <typename U>
 void CudaAllreduceRing<T, W>::init(
     typename std::enable_if<std::is_same<U, CudaDeviceWorkspace<T> >::value,
                             typename U::Pointer>::type*) {
-  // Since reduction is executed on the GPU, the scratch space
-  // can use an existing input buffer to accumulate.
-  auto& ptr = devicePtrs_[0];
+  // The networking adapter does DMA to/from GPU memory, so we should reduce
+  // onto the device that's closest to the networking adapter bound
+  // to our context. This uses PCI distance to find closest GPU.
+  auto& ptr = findCudaDevicePointerClosestToDevice(
+      devicePtrs_, this->context_->getDevice());
   auto count = ptr.getCount();
   scratch_ = CudaDevicePointer<T>::create(*ptr, count);
 

--- a/gloo/cuda_allreduce_ring_chunked.cc
+++ b/gloo/cuda_allreduce_ring_chunked.cc
@@ -309,9 +309,11 @@ template <typename U>
 void CudaAllreduceRingChunked<T, W>::init(
     typename std::enable_if<std::is_same<U, CudaDeviceWorkspace<T> >::value,
     typename U::Pointer>::type*) {
-  // Since reduction is executed on the GPU, the scratch space
-  // can use an existing input buffer to accumulate.
-  auto& ptr = devicePtrs_[0];
+  // The networking adapter does DMA to/from GPU memory, so we should reduce
+  // onto the device that's closest to the networking adapter bound
+  // to our context. This uses PCI distance to find closest GPU.
+  auto& ptr = findCudaDevicePointerClosestToDevice(
+      devicePtrs_, this->context_->getDevice());
   auto count = ptr.getCount();
   scratch_ = CudaDevicePointer<T>::create(*ptr, count);
 

--- a/gloo/mpi/context.cc
+++ b/gloo/mpi/context.cc
@@ -102,6 +102,7 @@ void Context::connectFullMesh(std::shared_ptr<transport::Device>& dev) {
     pairs[i]->connect(address);
   }
 
+  device_ = dev;
   pairs_ = std::move(pairs);
 }
 

--- a/gloo/rendezvous/context.cc
+++ b/gloo/rendezvous/context.cc
@@ -71,13 +71,9 @@ void Context::connectFullMesh(
     pairs[i]->connect(addr);
   }
 
+  device_ = dev;
   pairs_ = std::move(pairs);
 }
-
-void Context::setPairs(std::vector<std::unique_ptr<transport::Pair>>&& pairs) {
-  pairs_ = std::move(pairs);
-}
-
 
 ContextFactory::ContextFactory(std::shared_ptr<::gloo::Context> backingContext)
     : backingContext_(backingContext) {
@@ -194,7 +190,8 @@ std::shared_ptr<::gloo::Context> ContextFactory::makeContext(
     recvNotificationBuffers_[i]->waitRecv();
   }
 
-  context->setPairs(std::move(pairs));
+  context->device_ = dev;
+  context->pairs_ = std::move(pairs);
   return std::static_pointer_cast<::gloo::Context>(context);
 }
 

--- a/gloo/rendezvous/context.h
+++ b/gloo/rendezvous/context.h
@@ -24,6 +24,7 @@ class ContextFactory;
 
 class Context : public ::gloo::Context {
   friend class ContextFactory;
+
  public:
   Context(int rank, int size);
   virtual ~Context();
@@ -31,8 +32,8 @@ class Context : public ::gloo::Context {
   void connectFullMesh(
       Store& store,
       std::shared_ptr<transport::Device>& dev);
+
  protected:
-  void setPairs(std::vector<std::unique_ptr<transport::Pair>>&& pairs);
   std::vector<char> extractAddress(std::vector<char>& allAddrs, int i);
 };
 


### PR DESCRIPTION
This change also adds a device reference to the communication context. This is then used to determine PCI distance to all of the specified device pointers to determine which one is closest.