### PR TITLE
Multi-threading for benchmark tool

### DIFF
--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -49,6 +49,7 @@ static void usage(int status, const char* argv0) {
   X("      --elements         Number of floats to use per input buffer");
   X("      --iteration-count  Number of iterations to run benchmark for");
   X("      --iteration-time   Time to run benchmark for (default: 2s)");
+  X("      --threads          Number of threads to spawn (default: 1)");
   X("      --nanos            Display timing data in nanos instead of micros");
   X("      --gpudirect        Use GPUDirect (CUDA only)");
   X("      --halfprecision    Use 16-bit floating point values");
@@ -105,6 +106,7 @@ struct options parseOptions(int argc, char** argv) {
       {"gpudirect", no_argument, nullptr, 0x1009},
       {"halfprecision", no_argument, nullptr, 0x100a},
       {"destinations", required_argument, nullptr, 0x100b},
+      {"threads", required_argument, nullptr, 0x100c},
       {"help", no_argument, nullptr, 0xffff},
       {nullptr, 0, nullptr, 0}};
 
@@ -200,6 +202,11 @@ struct options parseOptions(int argc, char** argv) {
       case 0x100b: // --destinations
       {
         result.destinations = atoi(optarg);
+        break;
+      }
+      case 0x100c: // --threads
+      {
+        result.threads = atoi(optarg);
         break;
       }
       case 0xffff: // --help

--- a/gloo/benchmark/options.h
+++ b/gloo/benchmark/options.h
@@ -49,6 +49,7 @@ struct options {
   bool gpuDirect = false;
   bool halfPrecision = false;
   int destinations  = 1;
+  int threads = 1;
 };
 
 struct options parseOptions(int argc, char** argv);


### PR DESCRIPTION
This change makes it possible to run a particular algorithm in many parallel
threads. This puts more stress on the interconnect as any time the network used
to be idle can now be used by another thread. I collapsed the bandwidth reports
into a single metric reporting average bandwidth over the entire run.