### PR TITLE
Gloo fixes for Linux + old cmake (2.8.0) + old glibc (CentOS6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 project(gloo CXX C)
 

--- a/gloo/CMakeLists.txt
+++ b/gloo/CMakeLists.txt
@@ -64,7 +64,7 @@ configure_file(config.h.in config.h)
 
 # Prepend include path so that generated config.h is picked up.
 # Note that it is included as "gloo/config.h" to add parent directory.
-get_filename_component(PARENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} DIRECTORY)
+get_filename_component(PARENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} PATH)
 include_directories(BEFORE ${PARENT_BINARY_DIR})
 
 add_library(gloo ${GLOO_STATIC_OR_SHARED} ${GLOO_SRCS})
@@ -82,10 +82,7 @@ if(USE_CUDA)
 endif()
 
 # Add path to gloo/config.h so it is picked up by parent projects.
-target_include_directories(gloo BEFORE PUBLIC ${PARENT_BINARY_DIR})
-if(USE_CUDA)
-  target_include_directories(gloo_cuda BEFORE PUBLIC ${PARENT_BINARY_DIR})
-endif()
+include_directories(BEFORE ${PARENT_BINARY_DIR})
 
 # Install if necessary.
 # If the Gloo build is included from another project's build, it may

--- a/gloo/common/common.h
+++ b/gloo/common/common.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <malloc.h>
 #include <memory>
 
 namespace gloo {
@@ -47,7 +48,7 @@ class aligned_allocator {
   inline pointer allocate(
       size_type sz,
       typename std::allocator<void>::const_pointer = 0) {
-    auto x = aligned_alloc(ALIGNMENT, sizeof(T) * sz);
+    auto x = memalign(ALIGNMENT, sizeof(T) * sz);
     return reinterpret_cast<pointer>(x);
   }
 


### PR DESCRIPTION
let me know if you would like to have these changes.

Since gloo already assumes linux-only in some parts of the code, I used `memalign`. 
`aligned_alloc` is not present (unfortunately) in the glibc of centos6.

If you dont like these changes, I can create something more in the line of:
- check for aligned_alloc's existence during compile-time via cmake
- if available use it, else fallback to memalign

The reason I've ported the code back to the old cmake and old glibc is because when building binaries for PyTorch, we use CentOS6 (for the old glibc) so that the binaries run pretty much anywhere.