### PR TITLE
Take CUDA peer access into account for on-device reduction

### DIFF
--- a/gloo/cuda_collectives_device.h
+++ b/gloo/cuda_collectives_device.h
@@ -32,120 +32,228 @@ class CudaLocalDeviceReduce : public LocalOp<T> {
       size_t count)
       : streams_(streams),
         targetPtr_(targetPtr.range(offset, count)),
-        fn_(fn),
-        numPtrs_(devicePtrs.size()),
-        steps_(log2(numPtrs_)) {
-    // Only works with power-of-2 number of pointers
-    GLOO_ENFORCE(1 << steps_, streams.size(), "Not power of two");
-
+        fn_(fn) {
     // Incorporate offset/count into devicePtrs
     devicePtrs_.reserve(devicePtrs.size());
     for (const auto& ptr : devicePtrs) {
       devicePtrs_.push_back(ptr.range(offset, count));
     }
 
-    // Add level of indirection so that we can shuffle this instead
-    // of shuffling BOTH the streams and device ptr vectors.
-    for (auto i = 0; i < numPtrs_; i++) {
-      indices_.push_back(i);
-    }
+    // Initialize reduction sequence and setup peer access
+    computeIndices();
+    initializePeerAccess();
+  }
 
-    // Shuffle order in an attempt to evenly spread work across devices when
-    // dealing with multiple instances of this operation.
-    std::random_shuffle(indices_.begin(), indices_.end());
+  void queueReduction(int indexA, int indexB) {
+    auto& streamA = streams_[indexA];
+    auto& streamB = streams_[indexB];
 
-    // Initialize
-    CudaDeviceGuard guard;
-    for (auto i = 0; i < steps_; i++) {
-      auto sz = 1 << i;
-      for (auto j = 0; j < numPtrs_; j += sz * 2) {
-        auto indexA = indices_[j];
-        auto indexB = indices_[j + sz];
-        auto devA = devicePtrs_[indexA].getDeviceID();
-        auto devB = devicePtrs_[indexB].getDeviceID();
+    // Record event on secondary stream
+    CUDA_CHECK(cudaSetDevice(devicePtrs_[indexB].getDeviceID()));
+    CUDA_CHECK(cudaEventRecord(
+                   streamB.getEvent(),
+                   streamB.getStream()));
 
-        // Number of elements must be equal
-        GLOO_ENFORCE_EQ(
-            devicePtrs_[indexA].getCount(),
-            devicePtrs_[indexB].getCount());
+    // Make primary stream wait for secondary stream.
+    // This ensures any operations on the source pointer
+    // have finished before we start the reduction.
+    CUDA_CHECK(cudaSetDevice(devicePtrs_[indexA].getDeviceID()));
+    CUDA_CHECK(cudaStreamWaitEvent(
+                   streamA.getStream(),
+                   streamB.getEvent(),
+                   0));
 
-        // Devices must be able to access each others memory
-        int canAccessPeer = 0;
-        CUDA_CHECK(cudaDeviceCanAccessPeer(&canAccessPeer, devA, devB));
-        GLOO_ENFORCE_EQ(
-            1,
-            canAccessPeer,
-            "GPU ",
-            devA,
-            " does not have peer access to GPU ",
-            devB);
-
-        // Enable peer access for devA to memory on devB
-        CUDA_CHECK(cudaSetDevice(devA));
-        cudaDeviceEnablePeerAccess(devB, 0);
-
-        // Use cudaGetLastError so that any error is cleared.
-        auto err = cudaGetLastError();
-        if (err != cudaErrorPeerAccessAlreadyEnabled) {
-          CUDA_CHECK(err);
-        }
-      }
-    }
+    // Queue reduction
+    fn_->call(
+        devicePtrs_[indexA],
+        devicePtrs_[indexB],
+        devicePtrs_[indexA].getCount(),
+        streamA);
   }
 
   virtual void runAsync() {
     CudaDeviceGuard guard;
-    for (auto i = 0; i < steps_; i++) {
-      auto sz = 1 << i;
-      for (auto j = 0; j < numPtrs_; j += sz * 2) {
-        const auto indexA = indices_[j];
-        const auto indexB = indices_[j + sz];
-        auto& streamA = streams_[indexA];
-        auto& streamB = streams_[indexB];
 
-        // Record event on secondary stream
-        CUDA_CHECK(cudaSetDevice(devicePtrs_[indexB].getDeviceID()));
-        CUDA_CHECK(cudaEventRecord(
-                       streamB.getEvent(),
-                       streamB.getStream()));
-
-        // Make primary stream wait for secondary stream.
-        // This ensures any operations on the source pointer
-        // have finished before we start the reduction.
-        CUDA_CHECK(cudaSetDevice(devicePtrs_[indexA].getDeviceID()));
-        CUDA_CHECK(cudaStreamWaitEvent(
-                       streamA.getStream(),
-                       streamB.getEvent(),
-                       0));
-
-        // Queue reduction
-        fn_->call(
-            devicePtrs_[indexA],
-            devicePtrs_[indexB],
-            devicePtrs_[indexA].getCount(),
-            streamA);
+    // Queue reduction within groups
+    for (const auto& group : indices_) {
+      auto steps = log2(group.size());
+      for (auto i = 0; i < steps; i++) {
+        auto sz = 1 << i;
+        for (auto j = 0; j < group.size(); j += sz * 2) {
+          const auto indexA = group[j];
+          const auto indexB = group[j + sz];
+          queueReduction(indexA, indexB);
+        }
       }
     }
 
+    // Queue reduction across groups (if applicable)
+    if (indices_.size() > 1) {
+      queueReduction(indices_[0][0], indices_[1][0]);
+    }
+
     // Queue copy to target on the root stream
-    auto root = indices_[0];
+    auto root = indices_[0][0];
     streams_[root].copyAsync(targetPtr_, devicePtrs_[root]);
   }
 
   virtual void wait() {
     // Wait for the final memory copy to complete
-    auto root = indices_[0];
+    auto root = indices_[0][0];
     streams_[root].wait();
   }
 
  protected:
+  int findGroup(const std::vector<std::vector<int>>& groups, int device) {
+    for (auto j = 0; j < groups.size(); j++) {
+      auto& group = groups[j];
+      if (std::find(group.begin(), group.end(), device) != group.end()) {
+        return j;
+      }
+    }
+    // Sanity check
+    GLOO_ENFORCE(
+        false,
+        "Expected device ",
+        device,
+        " to be present in groupFullyConnected()");
+  }
+
+  // Ensures that the devices in group 0 have peer access to the device holding
+  // the target pointer. Then we know the final memcpy can be performed using
+  // peer access as well.
+  template <typename Dst1 = Dst>
+  void alignIndicesWithTarget(
+      const std::vector<std::vector<int>>& groups,
+      typename std::enable_if<
+          std::is_same<Dst1, CudaDevicePointer<T>>::value>::type* = 0) {
+    auto targetGroup = findGroup(groups, targetPtr_.getDeviceID());
+    if (targetGroup != 0) {
+      auto it = indices_.begin() + targetGroup;
+      auto group = std::move(*it);
+      indices_.erase(it);
+      indices_.insert(indices_.begin(), std::move(group));
+    }
+  }
+
+  // Ensures that the devices in group 0 are closest to the memory in
+  // the target pointer. The final memcpy will then be as fast as possible.
+  template <typename Dst1 = Dst>
+  void alignIndicesWithTarget(
+      const std::vector<std::vector<int>>& groups,
+      typename std::enable_if<
+          std::is_same<Dst1, CudaHostPointer<T>>::value>::type* = 0) {
+    // TODO
+  }
+
+  void computeIndices() {
+    // Add level of indirection so that we can shuffle this instead
+    // of shuffling BOTH the streams and device pointer vectors.
+    // Group indices by peer to peer access.
+    const auto& groups = groupFullyConnected();
+    GLOO_ENFORCE_LE(groups.size(), 2, "Expected <= 2 peer access groups");
+    indices_.resize(groups.size());
+    for (auto i = 0; i < devicePtrs_.size(); i++) {
+      indices_[findGroup(groups, devicePtrs_[i].getDeviceID())].push_back(i);
+    }
+    // Remove empty groups
+    for (auto it = indices_.begin(); it != indices_.end();) {
+      if (it->empty()) {
+        it = indices_.erase(it);
+      } else {
+        it++;
+      }
+    }
+    // Best effort alignment so that the group in indices[0] is close to target
+    if (indices_.size() > 1) {
+      alignIndicesWithTarget(groups);
+    }
+
+    // Shuffle order in an attempt to evenly spread work across devices when
+    // dealing with multiple instances of this operation.
+    auto& groupA = indices_[0];
+    std::random_shuffle(groupA.begin(), groupA.end());
+
+    // Make sure that the devices associated with the first element in
+    // each vector have peer to peer access, so we can reduce between groups.
+    // This is possible if this host uses the canonical NVLink topology.
+    if (indices_.size() > 1) {
+      auto devA = devicePtrs_[groupA.front()].getDeviceID();
+      auto& groupB = indices_[1];
+
+      // Find device with peer access to devA
+      auto ok = false;
+      for (auto it = groupB.begin(); it != groupB.end(); it++) {
+        if (canAccessPeer(devA, devicePtrs_[*it].getDeviceID())) {
+          // Move this index to front of vector
+          auto index = *it;
+          groupB.erase(it);
+          groupB.insert(groupB.begin(), index);
+          // Shuffle the remainder
+          std::random_shuffle(groupB.begin() + 1, groupB.end());
+          ok = true;
+          break;
+        }
+      }
+      GLOO_ENFORCE(ok, "Expected to find peer access between groups");
+    }
+  }
+
+  void enablePeerAccess(int indexA, int indexB) {
+    auto devA = devicePtrs_[indexA].getDeviceID();
+    auto devB = devicePtrs_[indexB].getDeviceID();
+
+    // Number of elements must be equal
+    GLOO_ENFORCE_EQ(
+        devicePtrs_[indexA].getCount(),
+        devicePtrs_[indexB].getCount());
+
+    // Devices must be able to access each others memory
+    GLOO_ENFORCE_EQ(
+        1,
+        canAccessPeer(devA, devB),
+        "GPU ",
+        devA,
+        " does not have peer access to GPU ",
+        devB);
+
+    // Enable peer access for devA to memory on devB
+    CudaDeviceScope scope(devA);
+    cudaDeviceEnablePeerAccess(devB, 0);
+
+    // Use cudaGetLastError so that any error is cleared.
+    auto err = cudaGetLastError();
+    if (err != cudaErrorPeerAccessAlreadyEnabled) {
+      CUDA_CHECK(err);
+    }
+  }
+
+  void initializePeerAccess() {
+    // Initialize peer access within groups
+    for (const auto& group : indices_) {
+      int steps = log2(group.size());
+      GLOO_ENFORCE(
+          1 << steps,
+          group.size(),
+          "Number of pointers in group not a power of two");
+      for (auto i = 0; i < steps; i++) {
+        auto sz = 1 << i;
+        for (auto j = 0; j < group.size(); j += sz * 2) {
+          enablePeerAccess(group[j], group[j + sz]);
+        }
+      }
+    }
+    // Initialize peer access across groups (if applicable)
+    if (indices_.size() > 1) {
+      enablePeerAccess(indices_[0].front(), indices_[1].front());
+    }
+  }
+
   std::vector<CudaStream>& streams_;
   std::vector<CudaDevicePointer<T> > devicePtrs_;
   Dst targetPtr_;
   const CudaReductionFunction<T>* fn_;
-  const int numPtrs_;
-  const int steps_;
-  std::vector<int> indices_;
+  std::vector<std::vector<int>> indices_;
 };
 
 // Below works both for CudaHostPointer and CudaDevicePointer

--- a/gloo/cuda_private.cu
+++ b/gloo/cuda_private.cu
@@ -9,6 +9,9 @@
 
 #include "gloo/cuda_private.h"
 
+#include <algorithm>
+#include <map>
+
 #include <cuda_fp16.h>
 
 #include "gloo/common/common.h"
@@ -110,6 +113,107 @@ const std::string& getCudaPCIBusID(int device) {
   });
 
   return busIDs[device];
+}
+
+bool canAccessPeer(int deviceA, int deviceB) {
+  static std::once_flag once;
+  static std::vector<int> canAccess;
+  static int count;
+
+  std::call_once(once, [](){
+    count = getDeviceCount();
+    canAccess.resize(count * count);
+    for (auto i = 0; i < count; i++) {
+      for (auto j = 0; j < count; j++) {
+        if (i == j) {
+          continue;
+        }
+
+        CUDA_CHECK(cudaDeviceCanAccessPeer(&canAccess[i * count + j], i, j));
+
+        // Verify symmetry
+        if (i > j) {
+          GLOO_ENFORCE_EQ(
+            canAccess[i * count + j],
+            canAccess[j * count + i],
+            "Expecting peer access to be symmetric");
+        }
+      }
+    }
+  });
+
+  return canAccess[deviceA * count + deviceB] == 1;
+}
+
+const std::vector<std::vector<int>>& groupFullyConnected() {
+  static std::once_flag once;
+  static std::vector<std::vector<int>> result;
+
+  std::call_once(once, [](){
+    // Generate grouping for all visible devices
+    auto count = getDeviceCount();
+    std::set<int> devices;
+    for (auto i = 0; i < count; i++) {
+      devices.insert(i);
+    }
+
+    // As long as there are ungrouped devices...
+    while (!devices.empty()) {
+      std::set<int> tmp;
+
+      // Use any elements from devices set as start
+      auto it = devices.begin();
+      auto root = *it;
+      tmp.insert(root);
+
+      // Fill tmp with devices with peer access to "root"
+      for (const auto& it : devices) {
+        if (canAccessPeer(root, it)) {
+          tmp.insert(it);
+        }
+      }
+
+      // Remove devices until we have a fully connected set
+      std::map<int, int> links;
+      while (tmp.size() > 2) {
+        links.clear();
+        for (const auto& i : tmp) {
+          for (const auto& j : tmp) {
+            if (canAccessPeer(i, j)) {
+              links[i]++;
+            }
+          }
+        }
+
+        // If tmp is fully connected, every links[X] == tmp.size() - 1
+        auto linkPredicate = [&tmp](const decltype(links)::value_type& it) {
+          return it.second == (tmp.size() - 1);
+        };
+        if (std::all_of(links.begin(), links.end(), linkPredicate)) {
+          break;
+        }
+
+        // Remove least connected device and try again
+        auto linkCompare = [](
+            const decltype(links)::value_type& l,
+            const decltype(links)::value_type& r) {
+          return l.second < r.second;
+        };
+        auto min = min_element(links.begin(), links.end(), linkCompare);
+        tmp.erase(min->first);
+      }
+
+      // All devices in tmp now have a home; remove them from devices set
+      for (const auto& it : tmp) {
+        devices.erase(it);
+      }
+
+      // Add to result
+      result.push_back(std::vector<int>(tmp.begin(), tmp.end()));
+    }
+  });
+
+  return result;
 }
 
 } // namespace gloo

--- a/gloo/cuda_private.h
+++ b/gloo/cuda_private.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <set>
 
 #include "gloo/common/linux.h"
 #include "gloo/common/logging.h"
@@ -88,6 +89,10 @@ CudaDevicePointer<T>& findCudaDevicePointerClosestToDevice(
   }
   return closest.get();
 }
+
+bool canAccessPeer(int deviceA, int deviceB);
+
+const std::vector<std::vector<int>>& groupFullyConnected();
 
 class CudaDeviceGuard {
  public:


### PR DESCRIPTION
The NVLink cube mesh architecture has partial peer access between devices. Two
groups of 4 GPUs have full peer access and every GPU in one group has peer
access to a corresponding GPU in the other group. When we reduce between all 8
GPUs, tree reduction using peer access must be done separately in those groups,
followed by a reduction across any one of the pairs connecting the groups. This
change refactors CudaDeviceReduce to work with this topology.

Additionally, it shuffles device pointers to randomize which GPUs run the
reduction and which communication links are used. The goal of randomization
here is to prevent excessive load on any single GPU or link.