### PR TITLE
Support multiple network devices in benchmark tool

### DIFF
--- a/gloo/benchmark/options.h
+++ b/gloo/benchmark/options.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "gloo/config.h"
 
@@ -31,9 +32,9 @@ struct options {
 
   // Transport
   std::string transport;
-  std::string ibverbsDevice = "mlx5_0";
+  std::vector<std::string> ibverbsDevice;
   int ibverbsPort = 1;
-  int ibverbsIndex = 1;
+  int ibverbsIndex = 0;
   bool sync = false;
   bool busyPoll = false;
 

--- a/gloo/benchmark/runner.h
+++ b/gloo/benchmark/runner.h
@@ -121,7 +121,7 @@ class Runner {
       const Distribution& samples);
 
   options options_;
-  std::shared_ptr<transport::Device> device_;
+  std::vector<std::shared_ptr<transport::Device>> transportDevices_;
   std::shared_ptr<rendezvous::ContextFactory> contextFactory_;
   std::vector<std::unique_ptr<RunnerThread>> threads_;
 


### PR DESCRIPTION
Systems such as the DGX-1 have more than one network adapter. This
change lets the benchmark tool use them. This option must be used
together with the --threads option. Threads pick up devices to use in a
round-robin fashion. If you run with 2 devices but with a 1 thread,
you'll still only run on 1 device; the first one. It is good practice to
use a number of threads equal to an integer multiple of the number of
devices.