### PR TITLE
Make CUDA algorithms use stream associated with scratch pointer

### DIFF
--- a/gloo/cuda.h
+++ b/gloo/cuda.h
@@ -120,6 +120,10 @@ class CudaDevicePointer {
 
   static CudaDevicePointer<T> create(T* ptr, size_t count);
 
+  static CudaDevicePointer<T> create(const CudaDevicePointer<T>& ptr) {
+    return CudaDevicePointer<T>::create(*ptr, ptr.getCount());
+  }
+
   CudaDevicePointer(CudaDevicePointer&&) noexcept;
   ~CudaDevicePointer();
 

--- a/gloo/cuda_allreduce_halving_doubling.h
+++ b/gloo/cuda_allreduce_halving_doubling.h
@@ -63,6 +63,7 @@ class CudaAllreduceHalvingDoubling : public Algorithm {
   std::vector<CudaDevicePointer<T> > devicePtrs_;
   std::vector<CudaStream> streams_;
   typename W::Pointer scratch_;
+  CudaStream* scratchStream_;
 
   const int count_;
   const int bytes_;

--- a/gloo/cuda_allreduce_ring.cc
+++ b/gloo/cuda_allreduce_ring.cc
@@ -69,7 +69,7 @@ CudaAllreduceRing<T, W>::CudaAllreduceRing(
 template <typename T, typename W>
 void CudaAllreduceRing<T, W>::run() {
   CudaDeviceGuard guard;
-  CudaStream& stream = streams_[0];
+  CudaStream& stream = *scratchStream_;
 
   if (localReduceOp_) {
     localReduceOp_->run();
@@ -125,6 +125,7 @@ void CudaAllreduceRing<T, W>::init(
   // Since reduction is executed on the CPU, the scratch space
   // where they are accumulated is a new host side buffer.
   scratch_ = W::Pointer::alloc(count_);
+  scratchStream_ = &streams_[0];
 
   // Execute local reduction and broadcast from host.
   // If devicePtrs_.size() == 1 these functions construct an op that
@@ -146,10 +147,10 @@ void CudaAllreduceRing<T, W>::init(
   // The networking adapter does DMA to/from GPU memory, so we should reduce
   // onto the device that's closest to the networking adapter bound
   // to our context. This uses PCI distance to find closest GPU.
-  auto& ptr = findCudaDevicePointerClosestToDevice(
+  auto index = findCudaDevicePointerClosestToDevice(
       devicePtrs_, this->context_->getDevice());
-  auto count = ptr.getCount();
-  scratch_ = CudaDevicePointer<T>::create(*ptr, count);
+  scratch_ = CudaDevicePointer<T>::create(devicePtrs_[index]);
+  scratchStream_ = &streams_[index];
 
   // Run local reduction and broadcast on device.
   // When running with a device workspace we intend to never leave the device.
@@ -164,8 +165,8 @@ void CudaAllreduceRing<T, W>::init(
   // cross device copies while accumulating the reduction.
   {
     CudaDeviceScope scope(scratch_.getDeviceID());
-    inbox_ = W::Pointer::alloc(count);
-    outbox_ = W::Pointer::alloc(count);
+    inbox_ = W::Pointer::alloc(count_);
+    outbox_ = W::Pointer::alloc(count_);
   }
 }
 

--- a/gloo/cuda_allreduce_ring.h
+++ b/gloo/cuda_allreduce_ring.h
@@ -43,6 +43,7 @@ class CudaAllreduceRing : public Algorithm {
   std::vector<CudaDevicePointer<T> > devicePtrs_;
   std::vector<CudaStream> streams_;
   typename W::Pointer scratch_;
+  CudaStream* scratchStream_;
 
   const int count_;
   const int bytes_;

--- a/gloo/cuda_allreduce_ring_chunked.h
+++ b/gloo/cuda_allreduce_ring_chunked.h
@@ -46,6 +46,7 @@ class CudaAllreduceRingChunked : public Algorithm {
   std::vector<CudaDevicePointer<T> > devicePtrs_;
   std::vector<CudaStream> streams_;
   typename W::Pointer scratch_;
+  CudaStream* scratchStream_;
 
   const int count_;
   const int bytes_;

--- a/gloo/cuda_private.h
+++ b/gloo/cuda_private.h
@@ -56,7 +56,7 @@ inline int getDeviceCount() {
 const std::string& getCudaPCIBusID(int device);
 
 template<typename T>
-CudaDevicePointer<T>& findCudaDevicePointerClosestToDevice(
+int findCudaDevicePointerClosestToDevice(
     std::vector<CudaDevicePointer<T> >& ptrs,
     std::shared_ptr<transport::Device>& dev) {
   // Compute distance between every pointer
@@ -77,16 +77,16 @@ CudaDevicePointer<T>& findCudaDevicePointerClosestToDevice(
   }
   // Choose random pointer closest to device;
   auto minOffset = rand() % minDistanceCount;
-  std::reference_wrapper<CudaDevicePointer<T>> closest = ptrs[0];
+  int minIndex = 0;
   for (auto i = 0; i < ptrs.size(); i++) {
     if (distance[i] == minDistance) {
       if (minOffset == 0) {
-        closest = ptrs[i];
+        minIndex = i;
       }
       minOffset--;
     }
   }
-  return closest.get();
+  return minIndex;
 }
 
 class CudaDeviceGuard {


### PR DESCRIPTION
These algorithms still defaulted to the stream of the first pointer.
When GPUDirect is used, we'll use a scratch buffer that is closest to
the networking adapter to minimize intra-machine communication.
However, since streams are pinned to devices, we have to use the
stream associated to the device that hosts the scratch buffer.