### PR TITLE
Dynamically pick default ibverbs device

### DIFF
--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -284,13 +284,6 @@ struct options parseOptions(int argc, char** argv) {
   result.mpi = (getenv("OMPI_UNIVERSE_SIZE") != nullptr);
 #endif
 
-  // Initialize default ibverbs device
-  if (result.transport == "ibverbs") {
-    if (result.ibverbsDevice.empty()) {
-      result.ibverbsDevice.push_back("mlx5_0");
-    }
-  }
-
   if (result.busyPoll && !result.sync) {
     fprintf(stderr, "%s: busy poll can only be used with sync mode\n", argv[0]);
     usage(EXIT_FAILURE, argv[0]);

--- a/gloo/benchmark/runner.cc
+++ b/gloo/benchmark/runner.cc
@@ -56,13 +56,19 @@ Runner::Runner(const options& options) : options_(options) {
 #endif
 #ifdef BENCHMARK_IBVERBS
   if (options_.transport == "ibverbs") {
-    for (const auto& name : options_.ibverbsDevice) {
-      transport::ibverbs::attr attr = {
-        .name = name,
-        .port = options_.ibverbsPort,
-        .index = options_.ibverbsIndex,
-      };
+    if (options_.ibverbsDevice.empty()) {
+      transport::ibverbs::attr attr;
+      attr.port = options_.ibverbsPort;
+      attr.index = options_.ibverbsIndex;
       transportDevices_.push_back(transport::ibverbs::CreateDevice(attr));
+    } else {
+      for (const auto& name : options_.ibverbsDevice) {
+        transport::ibverbs::attr attr;
+        attr.name = name;
+        attr.port = options_.ibverbsPort;
+        attr.index = options_.ibverbsIndex;
+        transportDevices_.push_back(transport::ibverbs::CreateDevice(attr));
+      }
     }
   }
 #endif


### PR DESCRIPTION
This was hardcoded as mlx5_0. With this change it will use the first device (lexographically sorted).