### PR TITLE
Ensure an ibverbs buffer has no in-flight sends when destructing

### DIFF
--- a/gloo/rendezvous/context.cc
+++ b/gloo/rendezvous/context.cc
@@ -181,13 +181,20 @@ std::shared_ptr<::gloo::Context> ContextFactory::makeContext(
     sendNotificationBuffers_[i]->send();
   }
 
-  // Wait for notification from peers
+  // Wait for incoming notification from peers
   for (auto i = 0; i < context->size; i++) {
     if (i == context->rank) {
       continue;
     }
-
     recvNotificationBuffers_[i]->waitRecv();
+  }
+
+  // Wait for outgoing notifications to be flushed
+  for (auto i = 0; i < context->size; i++) {
+    if (i == context->rank) {
+      continue;
+    }
+    sendNotificationBuffers_[i]->waitSend();
   }
 
   context->device_ = dev;

--- a/gloo/transport/ibverbs/buffer.cc
+++ b/gloo/transport/ibverbs/buffer.cc
@@ -52,6 +52,7 @@ Buffer::Buffer(Pair* pair, int slot, void* ptr, size_t size)
 }
 
 Buffer::~Buffer() {
+  GLOO_ENFORCE_EQ(sendPending_, 0, "Destructing buffer expecting completions");
   ibv_dereg_mr(mr_);
 }
 


### PR DESCRIPTION
If it is destroyed before all sends have completed, the pair will try
and call handleCompletion on a destructed buffer.

This is treating the symptom and not the cause. It would be better to
implement a deregistration mechanism such that the pair forgets about
the buffer altogether, as well as mechanism for the device to forget
about a pair upon destruction. I'll leave this as a todo.