### PR TITLE
Add function to check for GPUDirect support

### DIFF
--- a/gloo/transport/device.h
+++ b/gloo/transport/device.h
@@ -31,6 +31,8 @@ class Device {
 
   virtual int getInterfaceSpeed() const { return 0; }
 
+  virtual bool hasGPUDirect() const { return false; }
+
   virtual std::unique_ptr<Pair> createPair(
       std::chrono::milliseconds timeout) = 0;
 };

--- a/gloo/transport/ibverbs/device.cc
+++ b/gloo/transport/ibverbs/device.cc
@@ -156,6 +156,10 @@ const std::string& Device::getPCIBusID() const {
   return pciBusID_;
 }
 
+bool Device::hasGPUDirect() const {
+  return hasNvPeerMem_;
+}
+
 std::unique_ptr<transport::Pair> Device::createPair(
     std::chrono::milliseconds timeout) {
   if (timeout < std::chrono::milliseconds::zero()) {

--- a/gloo/transport/ibverbs/device.h
+++ b/gloo/transport/ibverbs/device.h
@@ -51,6 +51,8 @@ class Device : public ::gloo::transport::Device,
 
   virtual const std::string& getPCIBusID() const override;
 
+  virtual bool hasGPUDirect() const override;
+
   virtual std::unique_ptr<::gloo::transport::Pair> createPair(
       std::chrono::milliseconds timeout) override;
 


### PR DESCRIPTION
This only returns true if the ibverbs transport is used and the
nv_peer_mem kernel module is loaded.