### PR TITLE
Include hint when ibv_reg_mr returns ENOMEM

### DIFF
--- a/gloo/transport/ibverbs/buffer.cc
+++ b/gloo/transport/ibverbs/buffer.cc
@@ -48,6 +48,15 @@ Buffer::Buffer(Pair* pair, int slot, void* ptr, size_t size)
     }
   }
 
+  // Provide hint if the error is ENOMEM
+  if (mr_ == nullptr && errno == ENOMEM) {
+    GLOO_ENFORCE(
+      mr_ != nullptr,
+      "ibv_reg_mr: ",
+      strerror(errno),
+      " (did you run into the locked memory limit?)");
+  }
+
   GLOO_ENFORCE(mr_ != nullptr, "ibv_reg_mr: ", strerror(errno));
 }
 


### PR DESCRIPTION
The default error message showing ENOMEM on ibv_reg_mr is too cryptic,
where there is only one real cause (that I know of). Add this to the
error message hint to point users in the right direction.