### PR TITLE
Add AllreduceBuilder algorithm instance builder

### DIFF
--- a/gloo/CMakeLists.txt
+++ b/gloo/CMakeLists.txt
@@ -7,6 +7,7 @@ set(GLOO_HDRS)
 # Compiled sources in root directory
 list(APPEND GLOO_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/algorithm.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_local.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/context.cc"
   )
 
@@ -14,6 +15,7 @@ list(APPEND GLOO_HDRS
   "${CMAKE_CURRENT_SOURCE_DIR}/algorithm.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allgather_ring.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_halving_doubling.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_local.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_ring.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_ring_chunked.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/barrier.h"
@@ -36,6 +38,16 @@ if(USE_CUDA)
     "${CMAKE_CURRENT_SOURCE_DIR}/cuda*.h"
     )
 endif()
+
+# The builder links to both the base gloo library and gloo_cuda if
+# USE_CUDA is set. It can therefore not be part of either.
+list(APPEND GLOO_BUILDER_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_builder.cc"
+  )
+
+list(APPEND GLOO_BUILDER_HDRS
+  "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_builder.h"
+  )
 
 add_subdirectory(common)
 add_subdirectory(mpi)
@@ -72,14 +84,18 @@ get_filename_component(PARENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} DIRECTORY)
 include_directories(BEFORE ${PARENT_BINARY_DIR})
 
 add_library(gloo ${GLOO_STATIC_OR_SHARED} ${GLOO_SRCS})
+add_library(gloo_builder ${GLOO_STATIC_OR_SHARED} ${GLOO_BUILDER_SRCS})
 target_link_libraries(gloo ${gloo_DEPENDENCY_LIBS})
+target_link_libraries(gloo_builder gloo)
 if(USE_CUDA)
   cuda_add_library(gloo_cuda ${GLOO_CUDA_SRCS} ${GLOO_STATIC_OR_SHARED})
   target_link_libraries(gloo_cuda gloo ${gloo_cuda_DEPENDENCY_LIBS})
+  target_link_libraries(gloo_builder gloo_cuda)
 endif()
 
 # Add path to gloo/config.h so it is picked up by parent projects.
 target_include_directories(gloo BEFORE PUBLIC ${PARENT_BINARY_DIR})
+target_include_directories(gloo_builder BEFORE PUBLIC ${PARENT_BINARY_DIR})
 if(USE_CUDA)
   target_include_directories(gloo_cuda BEFORE PUBLIC ${PARENT_BINARY_DIR})
 endif()
@@ -89,12 +105,18 @@ endif()
 # want to statically link with Gloo and not install any artifacts.
 if(GLOO_INSTALL)
   install(TARGETS gloo DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+  install(TARGETS gloo_builder DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
   if(USE_CUDA)
     install(TARGETS gloo_cuda DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
   endif()
   install(FILES ${CMAKE_BINARY_DIR}/gloo/config.h
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include/gloo)
   foreach(HEADER ${GLOO_HDRS})
+    string(REGEX MATCH "(.*)[/\\]" DIR ${HEADER})
+    string(REGEX REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "gloo" DIR ${DIR})
+    install(FILES ${HEADER} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${DIR})
+  endforeach()
+  foreach(HEADER ${GLOO_BUILDER_HDRS})
     string(REGEX MATCH "(.*)[/\\]" DIR ${HEADER})
     string(REGEX REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "gloo" DIR ${DIR})
     install(FILES ${HEADER} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${DIR})

--- a/gloo/allreduce_builder.cc
+++ b/gloo/allreduce_builder.cc
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "gloo/allreduce_builder.h"
+
+#include <algorithm>
+
+#include "gloo/allreduce_halving_doubling.h"
+#include "gloo/allreduce_local.h"
+#include "gloo/allreduce_ring.h"
+#include "gloo/allreduce_ring_chunked.h"
+#include "gloo/common/logging.h"
+
+#if GLOO_USE_CUDA
+#include "gloo/cuda_allreduce_halving_doubling.h"
+#include "gloo/cuda_allreduce_halving_doubling_pipelined.h"
+#include "gloo/cuda_allreduce_local.h"
+#include "gloo/cuda_allreduce_ring.h"
+#include "gloo/cuda_allreduce_ring_chunked.h"
+#endif
+
+namespace gloo {
+
+template <typename T>
+AllreduceBuilder<T>::AllreduceBuilder()
+    : reductionType_(SUM),
+      implementation_(HalvingDoubling) {
+}
+
+template <typename T>
+AllreduceBuilder<T> AllreduceBuilder<T>::setInputs(
+    const std::vector<T*>& inputs) const {
+  AllreduceBuilder copy(*this);
+  copy.inputs_ = inputs;
+  return copy;
+}
+
+template <typename T>
+AllreduceBuilder<T> AllreduceBuilder<T>::setCount(
+    int count) const {
+  AllreduceBuilder<T> copy(*this);
+  copy.count_ = count;
+  return copy;
+}
+
+template <typename T>
+AllreduceBuilder<T> AllreduceBuilder<T>::setReductionType(
+    ReductionType reductionType) const {
+  AllreduceBuilder<T> copy(*this);
+  copy.reductionType_ = reductionType;
+  return copy;
+}
+
+template <typename T>
+AllreduceBuilder<T> AllreduceBuilder<T>::setImplementation(
+    Implementation implementation) const {
+  AllreduceBuilder<T> copy(*this);
+  copy.implementation_ = implementation;
+  return copy;
+}
+
+#if GLOO_USE_CUDA
+
+template <typename T>
+AllreduceBuilder<T> AllreduceBuilder<T>::setStreams(
+    const std::vector<cudaStream_t>& streams) const {
+  AllreduceBuilder<T> copy(*this);
+  copy.streams_ = streams;
+  return copy;
+}
+
+template <typename T>
+AllreduceBuilder<T> AllreduceBuilder<T>::useGPUDirect() const {
+  AllreduceBuilder<T> copy(*this);
+  copy.gpuDirect_ = true;
+  return copy;
+}
+
+namespace {
+
+template <
+  template <typename T, typename W> class A,
+  typename T,
+  typename ...Params>
+std::unique_ptr<Algorithm> getAlgorithmCuda(
+    bool gpuDirect,
+    Params&&... params) {
+  if (gpuDirect) {
+    return std::unique_ptr<::gloo::Algorithm>(
+      new A<T, CudaDeviceWorkspace<T>>(
+        std::forward<Params>(params)...));
+  } else {
+    return std::unique_ptr<::gloo::Algorithm>(
+      new A<T, CudaHostWorkspace<T>>(
+        std::forward<Params>(params)...));
+  }
+}
+
+} // namespace
+
+#endif
+
+template <typename T>
+std::unique_ptr<Algorithm> AllreduceBuilder<T>::getAlgorithm(
+    std::shared_ptr<Context>& context) {
+#if GLOO_USE_CUDA
+  // Instantiate CUDA algorithm if all pointers are GPU pointers
+  if (std::all_of(inputs_.begin(), inputs_.end(), [](const T* ptr) {
+        cudaPointerAttributes attr;
+        auto rv = cudaPointerGetAttributes(&attr, ptr);
+        return rv == cudaSuccess && attr.memoryType == cudaMemoryTypeDevice;
+      })) {
+    // TODO(pietern): Pass through the right reduction function to algorithm
+    if (context->size == 1) {
+      return std::unique_ptr<::gloo::Algorithm>(
+        new CudaAllreduceLocal<T>(
+          context,
+          inputs_,
+          count_,
+          streams_));
+    }
+
+    switch (implementation_) {
+      case HalvingDoubling:
+        return getAlgorithmCuda<CudaAllreduceHalvingDoubling, T>(
+          gpuDirect_, context, inputs_, count_, streams_);
+        break;
+      case HalvingDoublingPipelined:
+        return getAlgorithmCuda<CudaAllreduceHalvingDoublingPipelined, T>(
+          gpuDirect_, context, inputs_, count_, streams_);
+        break;
+      case Ring:
+        return getAlgorithmCuda<CudaAllreduceRing, T>(
+          gpuDirect_, context, inputs_, count_, streams_);
+        break;
+      case RingChunked:
+        return getAlgorithmCuda<CudaAllreduceRingChunked, T>(
+          gpuDirect_, context, inputs_, count_, streams_);
+        break;
+      default:
+        GLOO_ENFORCE(false, "Unhandled implementation: ", implementation_);
+        break;
+    }
+  }
+#endif
+
+  const ReductionFunction<T>* fn;
+  switch (reductionType_) {
+    case SUM:
+      fn = ReductionFunction<T>::sum;
+      break;
+    case PRODUCT:
+      fn = ReductionFunction<T>::product;
+      break;
+    case MIN:
+      fn = ReductionFunction<T>::min;
+      break;
+    case MAX:
+      fn = ReductionFunction<T>::max;
+      break;
+    default:
+      GLOO_ENFORCE(false, "Unhandled reduction type: ", reductionType_);
+      break;
+  }
+
+  if (context->size == 1) {
+    return std::unique_ptr<::gloo::Algorithm>(
+      new AllreduceLocal<T>(context, inputs_, count_, fn));
+  }
+
+  switch (implementation_) {
+    case HalvingDoubling:
+      return std::unique_ptr<::gloo::Algorithm>(
+        new AllreduceHalvingDoubling<T>(context, inputs_, count_, fn));
+      break;
+    case HalvingDoublingPipelined:
+      return std::unique_ptr<::gloo::Algorithm>(
+        new AllreduceHalvingDoubling<T>(context, inputs_, count_, fn));
+      break;
+    case Ring:
+      return std::unique_ptr<::gloo::Algorithm>(
+        new AllreduceRing<T>(context, inputs_, count_, fn));
+      break;
+    case RingChunked:
+      return std::unique_ptr<::gloo::Algorithm>(
+        new AllreduceRingChunked<T>(context, inputs_, count_, fn));
+      break;
+    default:
+      GLOO_ENFORCE(false, "Unhandled implementation: ", implementation_);
+      break;
+  }
+}
+
+// Instantiate templates
+#define INSTANTIATE_TEMPLATE(T) template class AllreduceBuilder<T>;
+
+INSTANTIATE_TEMPLATE(int8_t);
+INSTANTIATE_TEMPLATE(int32_t);
+INSTANTIATE_TEMPLATE(int64_t);
+INSTANTIATE_TEMPLATE(uint64_t);
+INSTANTIATE_TEMPLATE(float);
+INSTANTIATE_TEMPLATE(double);
+INSTANTIATE_TEMPLATE(float16);
+
+} // namespace gloo

--- a/gloo/allreduce_builder.h
+++ b/gloo/allreduce_builder.h
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "gloo/algorithm.h"
+#include "gloo/config.h"
+#include "gloo/context.h"
+
+#if GLOO_USE_CUDA
+#include "gloo/cuda.h"
+#endif
+
+namespace gloo {
+
+template <typename T>
+class AllreduceBuilder {
+ public:
+  enum Implementation {
+    HalvingDoubling,
+    HalvingDoublingPipelined,
+    Ring,
+    RingChunked,
+  };
+
+  AllreduceBuilder();
+
+  AllreduceBuilder(const AllreduceBuilder& rhs) = default;
+
+  AllreduceBuilder<T> setInputs(const std::vector<T*>& inputs) const;
+
+  AllreduceBuilder<T> setCount(int count) const;
+
+  AllreduceBuilder<T> setReductionType(ReductionType reductionType) const;
+
+  AllreduceBuilder<T> setImplementation(Implementation implementation) const;
+
+#if GLOO_USE_CUDA
+  AllreduceBuilder<T> setStreams(
+      const std::vector<cudaStream_t>& streams) const;
+
+  AllreduceBuilder<T> useGPUDirect() const;
+#endif
+
+  std::unique_ptr<Algorithm> getAlgorithm(std::shared_ptr<Context>& context);
+
+ protected:
+  std::vector<T*> inputs_;
+  std::vector<T*> outputs_;
+  int count_;
+  ReductionType reductionType_;
+  Implementation implementation_;
+
+#if GLOO_USE_CUDA
+  std::vector<cudaStream_t> streams_;
+  bool gpuDirect_;
+#endif
+};
+
+} // namespace

--- a/gloo/allreduce_local.cc
+++ b/gloo/allreduce_local.cc
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "gloo/allreduce_local.h"
+
+#include <stddef.h>
+#include <string.h>
+
+namespace gloo {
+
+template <typename T>
+AllreduceLocal<T>::AllreduceLocal(
+    const std::shared_ptr<Context>& context,
+    const std::vector<T*>& ptrs,
+    const int count,
+    const ReductionFunction<T>* fn)
+    : Algorithm(context),
+      ptrs_(ptrs),
+      count_(count),
+      bytes_(count_ * sizeof(T)),
+      fn_(fn) {
+}
+
+template <typename T>
+void AllreduceLocal<T>::run() {
+  // Reduce specified pointers into ptrs_[0]
+  for (int i = 1; i < ptrs_.size(); i++) {
+    fn_->call(ptrs_[0], ptrs_[i], count_);
+  }
+  // Broadcast ptrs_[0]
+  for (int i = 1; i < ptrs_.size(); i++) {
+    memcpy(ptrs_[i], ptrs_[0], bytes_);
+  }
+}
+
+// Instantiate templates
+#define INSTANTIATE_TEMPLATE(T) template class AllreduceLocal<T>;
+
+INSTANTIATE_TEMPLATE(int8_t);
+INSTANTIATE_TEMPLATE(int32_t);
+INSTANTIATE_TEMPLATE(int64_t);
+INSTANTIATE_TEMPLATE(uint64_t);
+INSTANTIATE_TEMPLATE(float);
+INSTANTIATE_TEMPLATE(double);
+INSTANTIATE_TEMPLATE(float16);
+
+} // namespace gloo

--- a/gloo/allreduce_local.h
+++ b/gloo/allreduce_local.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include "gloo/algorithm.h"
+#include "gloo/context.h"
+
+namespace gloo {
+
+template <typename T>
+class AllreduceLocal : public Algorithm {
+ public:
+  AllreduceLocal(
+      const std::shared_ptr<Context>& context,
+      const std::vector<T*>& ptrs,
+      const int count,
+      const ReductionFunction<T>* fn = ReductionFunction<T>::sum);
+
+  virtual ~AllreduceLocal() = default;
+
+  virtual void run() override;
+
+ protected:
+  std::vector<T*> ptrs_;
+  const int count_;
+  const int bytes_;
+  const ReductionFunction<T>* fn_;
+};
+
+} // namespace gloo

--- a/gloo/benchmark/CMakeLists.txt
+++ b/gloo/benchmark/CMakeLists.txt
@@ -24,7 +24,7 @@ if(USE_CUDA)
     )
 
   cuda_add_executable(benchmark_cuda ${GLOO_BENCHMARK_CUDA_SRCS})
-  target_link_libraries(benchmark_cuda gloo_cuda)
+  target_link_libraries(benchmark_cuda gloo_builder)
 
   if(GLOO_INSTALL)
     install(TARGETS benchmark_cuda DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/gloo/benchmark/cuda_main.cc
+++ b/gloo/benchmark/cuda_main.cc
@@ -10,13 +10,10 @@
 #include <map>
 #include <memory>
 
+#include "gloo/allreduce_builder.h"
 #include "gloo/benchmark/benchmark.h"
 #include "gloo/benchmark/runner.h"
 #include "gloo/common/logging.h"
-#include "gloo/cuda_allreduce_halving_doubling.h"
-#include "gloo/cuda_allreduce_halving_doubling_pipelined.h"
-#include "gloo/cuda_allreduce_ring.h"
-#include "gloo/cuda_allreduce_ring_chunked.h"
 #include "gloo/cuda_broadcast_one_to_all.h"
 #include "gloo/cuda_private.h"
 
@@ -34,6 +31,7 @@ int cudaNumDevices() {
 template <typename T>
 class CudaBenchmark : public Benchmark<T> {
   using Benchmark<T>::Benchmark;
+
  public:
   virtual ~CudaBenchmark() {}
 
@@ -56,13 +54,23 @@ class CudaBenchmark : public Benchmark<T> {
   std::vector<CudaMemory<T>> inputs_;
 };
 
-template <class A, typename T>
+template <typename T>
 class CudaAllreduceBenchmark : public CudaBenchmark<T> {
-  using CudaBenchmark<T>::CudaBenchmark;
  public:
+  CudaAllreduceBenchmark(
+    std::shared_ptr<::gloo::Context>& context,
+    struct options& options,
+    ::gloo::AllreduceBuilder<T> builder)
+      : CudaBenchmark<T>(context, options),
+        builder_(builder) {
+  }
+
   virtual void initialize(int elements) override {
     auto ptrs = this->allocate(this->options_.inputs, elements);
-    this->algorithm_.reset(new A(this->context_, ptrs, elements));
+    this->algorithm_ = builder_.
+      setInputs(ptrs).
+      setCount(elements).
+      getAlgorithm(this->context_);
   }
 
   virtual void verify() override {
@@ -82,6 +90,9 @@ class CudaAllreduceBenchmark : public CudaBenchmark<T> {
       }
     }
   }
+
+ protected:
+  ::gloo::AllreduceBuilder<T> builder_;
 };
 
 template <class A, typename T>
@@ -113,119 +124,62 @@ class CudaBroadcastOneToAllBenchmark : public CudaBenchmark<T> {
 
 } // namespace
 
-#define RUN_BENCHMARK(T)                                                    \
-  std::map<std::string, Runner::BenchmarkFn<T>> hostBenchmarks = {          \
-      {                                                                     \
-          "cuda_allreduce_halving_doubling",                                \
-          [&](std::shared_ptr<Context>& context) {                          \
-            using Algorithm =                                               \
-                CudaAllreduceHalvingDoubling<T, CudaHostWorkspace<T>>;      \
-            using Benchmark = CudaAllreduceBenchmark<Algorithm, T>;         \
-            return gloo::make_unique<Benchmark>(context, x);                \
-          },                                                                \
-      },                                                                    \
-      {                                                                     \
-          "cuda_allreduce_halving_doubling_pipelined",                      \
-          [&](std::shared_ptr<Context>& context) {                          \
-            using Algorithm = CudaAllreduceHalvingDoublingPipelined<        \
-                T,                                                          \
-                CudaHostWorkspace<T>>;                                      \
-            using Benchmark = CudaAllreduceBenchmark<Algorithm, T>;         \
-            return gloo::make_unique<Benchmark>(context, x);                \
-          },                                                                \
-      },                                                                    \
-      {                                                                     \
-          "cuda_allreduce_ring",                                            \
-          [&](std::shared_ptr<Context>& context) {                          \
-            using Algorithm = CudaAllreduceRing<T, CudaHostWorkspace<T>>;   \
-            using Benchmark = CudaAllreduceBenchmark<Algorithm, T>;         \
-            return gloo::make_unique<Benchmark>(context, x);                \
-          },                                                                \
-      },                                                                    \
-      {                                                                     \
-          "cuda_allreduce_ring_chunked",                                    \
-          [&](std::shared_ptr<Context>& context) {                          \
-            using Algorithm = CudaAllreduceRingChunked<T>;                  \
-            using Benchmark = CudaAllreduceBenchmark<Algorithm, T>;         \
-            return gloo::make_unique<Benchmark>(context, x);                \
-          },                                                                \
-      },                                                                    \
-      {                                                                     \
-          "cuda_broadcast_one_to_all",                                      \
-          [&](std::shared_ptr<Context>& context) {                          \
-            using Algorithm = CudaBroadcastOneToAll<T>;                     \
-            using Benchmark = CudaBroadcastOneToAllBenchmark<Algorithm, T>; \
-            return gloo::make_unique<Benchmark>(context, x);                \
-          },                                                                \
-      },                                                                    \
-  };                                                                        \
-                                                                            \
-  std::map<std::string, Runner::BenchmarkFn<T>> deviceBenchmarks = {        \
-      {                                                                     \
-          "cuda_allreduce_halving_doubling",                                \
-          [&](std::shared_ptr<Context>& context) {                          \
-            using Algorithm =                                               \
-                CudaAllreduceHalvingDoubling<T, CudaDeviceWorkspace<T>>;    \
-            using Benchmark = CudaAllreduceBenchmark<Algorithm, T>;         \
-            return gloo::make_unique<Benchmark>(context, x);                \
-          },                                                                \
-      },                                                                    \
-      {                                                                     \
-          "cuda_allreduce_halving_doubling_pipelined",                      \
-          [&](std::shared_ptr<Context>& context) {                          \
-            using Algorithm = CudaAllreduceHalvingDoublingPipelined<        \
-                T,                                                          \
-                CudaDeviceWorkspace<T>>;                                    \
-            using Benchmark = CudaAllreduceBenchmark<Algorithm, T>;         \
-            return gloo::make_unique<Benchmark>(context, x);                \
-          },                                                                \
-      },                                                                    \
-      {                                                                     \
-          "cuda_allreduce_ring",                                            \
-          [&](std::shared_ptr<Context>& context) {                          \
-            using Algorithm = CudaAllreduceRing<T, CudaDeviceWorkspace<T>>; \
-            using Benchmark = CudaAllreduceBenchmark<Algorithm, T>;         \
-            return gloo::make_unique<Benchmark>(context, x);                \
-          },                                                                \
-      },                                                                    \
-      {                                                                     \
-          "cuda_allreduce_ring_chunked",                                    \
-          [&](std::shared_ptr<Context>& context) {                          \
-            using Algorithm =                                               \
-                CudaAllreduceRingChunked<T, CudaDeviceWorkspace<T>>;        \
-            using Benchmark = CudaAllreduceBenchmark<Algorithm, T>;         \
-            return gloo::make_unique<Benchmark>(context, x);                \
-          },                                                                \
-      },                                                                    \
-  };                                                                        \
-                                                                            \
-  Runner::BenchmarkFn<T> fn;                                                \
-  if (x.gpuDirect) {                                                        \
-    auto it = deviceBenchmarks.find(x.benchmark);                           \
-    if (it != deviceBenchmarks.end()) {                                     \
-      fn = it->second;                                                      \
-    }                                                                       \
-  } else {                                                                  \
-    auto it = hostBenchmarks.find(x.benchmark);                             \
-    if (it != hostBenchmarks.end()) {                                       \
-      fn = it->second;                                                      \
-    }                                                                       \
-  }                                                                         \
-                                                                            \
-  if (!fn) {                                                                \
-    GLOO_ENFORCE(false, "Invalid algorithm: ", x.benchmark);                \
-  }                                                                         \
-                                                                            \
-  Runner r(x);                                                              \
+template <class TC>
+bool beginsWith(const TC& input, const TC& match) {
+  return input.size() >= match.size()
+    && equal(match.begin(), match.end(), input.begin());
+}
+
+template <typename T>
+void runBenchmark(options& x) {
+  Runner::BenchmarkFn<T> fn;
+
+  if (x.benchmark == "cuda_broadcast_one_to_all") {
+    fn = [&](std::shared_ptr<Context>& context) {
+      using Algorithm = CudaBroadcastOneToAll<T>;
+      using Benchmark = CudaBroadcastOneToAllBenchmark<Algorithm, T>;
+      return gloo::make_unique<Benchmark>(context, x);
+    };
+  } else if (beginsWith(x.benchmark, std::string("cuda_allreduce_"))) {
+    auto builder = gloo::AllreduceBuilder<T>();
+    if (x.gpuDirect) {
+      builder = builder.useGPUDirect();
+    }
+    if (x.benchmark == "cuda_allreduce_halving_doubling") {
+      builder = builder.setImplementation(
+        gloo::AllreduceBuilder<T>::HalvingDoubling);
+    } else if (x.benchmark == "cuda_allreduce_halving_doubling_pipelined") {
+      builder = builder.setImplementation(
+        gloo::AllreduceBuilder<T>::HalvingDoublingPipelined);
+    } else if (x.benchmark == "cuda_allreduce_ring") {
+      builder = builder.setImplementation(
+        gloo::AllreduceBuilder<T>::Ring);
+    } else if (x.benchmark == "cuda_allreduce_ring_chunked") {
+      builder = builder.setImplementation(
+        gloo::AllreduceBuilder<T>::RingChunked);
+    } else {
+      GLOO_ENFORCE(false, "Invalid algorithm: ", x.benchmark);
+    }
+    fn = [&, builder](std::shared_ptr<Context>& context) {
+      return std::unique_ptr<Benchmark<T>>(
+        new CudaAllreduceBenchmark<T>(context, x, builder));
+    };
+  }
+
+  if (!fn) {
+    GLOO_ENFORCE(false, "Invalid algorithm: ", x.benchmark);
+  }
+
+  Runner r(x);
   r.run(fn);
+}
 
 int main(int argc, char** argv) {
   auto x = benchmark::parseOptions(argc, argv);
-
   if (x.halfPrecision) {
-    RUN_BENCHMARK(float16);
+    runBenchmark<float16>(x);
   } else {
-    RUN_BENCHMARK(float);
+    runBenchmark<float>(x);
   }
   return 0;
 }

--- a/gloo/cuda_allreduce_local.cc
+++ b/gloo/cuda_allreduce_local.cc
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "gloo/cuda_allreduce_local.h"
+
+#include "gloo/common/logging.h"
+#include "gloo/cuda_collectives_device.h"
+#include "gloo/cuda_private.h"
+
+namespace gloo {
+
+template <typename T>
+CudaAllreduceLocal<T>::CudaAllreduceLocal(
+  const std::shared_ptr<Context>& context,
+  const std::vector<T*>& ptrs,
+  const int count,
+  const std::vector<cudaStream_t>& streams)
+    : Algorithm(context),
+      count_(count),
+      bytes_(count_ * sizeof(T)),
+      synchronizeDeviceOutputs_(streams.size() == 0),
+      fn_(CudaReductionFunction<T>::sum) {
+  auto newStream = true;
+  if (streams.size() > 0) {
+    GLOO_ENFORCE_EQ(streams.size(), ptrs.size());
+    newStream = false;
+  }
+
+  for (auto i = 0; i < ptrs.size(); i++) {
+    auto ptr = CudaDevicePointer<T>::create(ptrs[i], count_);
+    if (newStream) {
+      streams_.push_back(CudaStream(ptr.getDeviceID()));
+    } else {
+      streams_.push_back(CudaStream(ptr.getDeviceID(), streams[i]));
+    }
+    devicePtrs_.push_back(std::move(ptr));
+  }
+
+  // Initialize local reduce / local broadcast
+  // TODO(pietern): Optimize this to use real direct allreduce if possible
+  if (devicePtrs_.size() > 1) {
+    localReduceOp_ =
+      cudaDeviceReduce(streams_, devicePtrs_, devicePtrs_[0], fn_, 0, count_);
+    localBroadcastOp_ =
+      cudaDeviceBroadcast(streams_, devicePtrs_, devicePtrs_[0], 0, count_);
+  }
+}
+
+template <typename T>
+void CudaAllreduceLocal<T>::run() {
+  CudaDeviceGuard guard;
+
+  if (devicePtrs_.size() > 1) {
+    localReduceOp_->runAsync();
+    localBroadcastOp_->runAsync();
+    if (synchronizeDeviceOutputs_) {
+      localBroadcastOp_->wait();
+    }
+  }
+}
+
+// Instantiate templates
+#define INSTANTIATE_TEMPLATE(T) template class CudaAllreduceLocal<T>;
+
+INSTANTIATE_TEMPLATE(int8_t);
+INSTANTIATE_TEMPLATE(int32_t);
+INSTANTIATE_TEMPLATE(int64_t);
+INSTANTIATE_TEMPLATE(uint64_t);
+INSTANTIATE_TEMPLATE(float);
+INSTANTIATE_TEMPLATE(double);
+INSTANTIATE_TEMPLATE(float16);
+
+} // namespace gloo

--- a/gloo/cuda_allreduce_local.h
+++ b/gloo/cuda_allreduce_local.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include "gloo/algorithm.h"
+#include "gloo/cuda.h"
+
+namespace gloo {
+
+template <typename T>
+class CudaAllreduceLocal : public Algorithm {
+ public:
+  CudaAllreduceLocal(
+      const std::shared_ptr<Context>& context,
+      const std::vector<T*>& ptrs,
+      const int count,
+      const std::vector<cudaStream_t>& streams = std::vector<cudaStream_t>());
+
+  virtual ~CudaAllreduceLocal() = default;
+
+  virtual void run() override;
+
+ protected:
+  std::vector<CudaDevicePointer<T> > devicePtrs_;
+  std::vector<CudaStream> streams_;
+  const int count_;
+  const int bytes_;
+  const CudaReductionFunction<T>* fn_;
+  const bool synchronizeDeviceOutputs_;
+
+  std::unique_ptr<LocalOp<T> > localReduceOp_;
+  std::unique_ptr<LocalOp<T> > localBroadcastOp_;
+};
+
+} // namespace gloo

--- a/gloo/test/CMakeLists.txt
+++ b/gloo/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(GLOO_TEST_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_builder_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/barrier_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/broadcast_test.cc"
@@ -7,10 +8,11 @@ set(GLOO_TEST_SRCS
   )
 
 add_executable(test ${GLOO_TEST_SRCS})
-target_link_libraries(test gloo gtest)
+target_link_libraries(test gloo gloo_builder gtest)
 
 if(USE_CUDA)
   set(GLOO_TEST_CUDA_SRCS
+    "${CMAKE_CURRENT_SOURCE_DIR}/cuda_allreduce_builder_test.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/cuda_allreduce_test.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/cuda_base_test.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/cuda_broadcast_test.cc"
@@ -18,5 +20,5 @@ if(USE_CUDA)
     )
 
   cuda_add_executable(test_cuda ${GLOO_TEST_CUDA_SRCS})
-  target_link_libraries(test_cuda gloo_cuda gtest)
+  target_link_libraries(test_cuda gloo_cuda gloo_builder gtest)
 endif()

--- a/gloo/test/allreduce_builder_test.cc
+++ b/gloo/test/allreduce_builder_test.cc
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "gloo/test/base_test.h"
+
+#include "gloo/allreduce_builder.h"
+
+namespace gloo {
+namespace test {
+namespace {
+
+template <typename T>
+class AllreduceBuilderTest : public BaseTest {
+};
+
+typedef ::testing::Types<
+  int8_t,
+  int32_t,
+  int64_t,
+  uint64_t,
+  float,
+  double,
+  float16> AllreduceBuilderTypes;
+
+TYPED_TEST_CASE(AllreduceBuilderTest, AllreduceBuilderTypes);
+
+TYPED_TEST(AllreduceBuilderTest, Test) {
+  std::vector<enum ::gloo::AllreduceBuilder<TypeParam>::Implementation> impls =
+    {
+      ::gloo::AllreduceBuilder<TypeParam>::HalvingDoubling,
+      ::gloo::AllreduceBuilder<TypeParam>::HalvingDoublingPipelined,
+      ::gloo::AllreduceBuilder<TypeParam>::Ring,
+      ::gloo::AllreduceBuilder<TypeParam>::RingChunked,
+    };
+
+  ::gloo::AllreduceBuilder<TypeParam> builder;
+
+  // Only test with 10 elements; this is not an algorithm implementation test
+  auto count = 10;
+
+  // Works for context size 1 or > 1
+  for (auto size = 1; size <= 2; size++) {
+    this->spawn(size, [&](std::shared_ptr<Context> context) {
+        for (const auto impl : impls) {
+          // Works for 1 or > 1 inputs
+          for (auto inputs = 1; inputs <= 2; inputs++) {
+            Fixture<TypeParam> f(context, inputs, count);
+            f.assignValues();
+
+            // Build and run algoritm
+            auto algorithm = builder.
+              setInputs(f.getPointers()).
+              setCount(count).
+              setImplementation(impl).
+              getAlgorithm(context);
+            algorithm->run();
+
+            // Verify results
+            f.checkAllreduceResult();
+          }
+        }
+      });
+  }
+}
+
+} // namespace
+} // namespace test
+} // namespace gloo

--- a/gloo/test/cuda_allreduce_builder_test.cc
+++ b/gloo/test/cuda_allreduce_builder_test.cc
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "gloo/test/cuda_base_test.h"
+
+#include "gloo/allreduce_builder.h"
+
+namespace gloo {
+namespace test {
+namespace {
+
+template <typename T>
+class CudaAllreduceBuilderTest : public BaseTest {
+};
+
+typedef ::testing::Types<
+  float,
+  float16> CudaAllreduceBuilderTypes;
+
+TYPED_TEST_CASE(CudaAllreduceBuilderTest, CudaAllreduceBuilderTypes);
+
+TYPED_TEST(CudaAllreduceBuilderTest, Test) {
+  std::vector<enum ::gloo::AllreduceBuilder<TypeParam>::Implementation> impls =
+    {
+      ::gloo::AllreduceBuilder<TypeParam>::HalvingDoubling,
+      ::gloo::AllreduceBuilder<TypeParam>::HalvingDoublingPipelined,
+      ::gloo::AllreduceBuilder<TypeParam>::Ring,
+      ::gloo::AllreduceBuilder<TypeParam>::RingChunked,
+    };
+
+  ::gloo::AllreduceBuilder<TypeParam> builder;
+
+  // Only test with 10 elements; this is not an algorithm implementation test
+  auto count = 10;
+
+  // Works for context size 1 or > 1
+  for (auto size = 1; size <= 2; size++) {
+    this->spawn(size, [&](std::shared_ptr<Context> context) {
+        for (const auto impl : impls) {
+          // Works for 1 or > 1 inputs
+          for (auto inputs = 1; inputs <= 2; inputs++) {
+            CudaFixture<TypeParam> f(context, inputs, count);
+            f.assignValues();
+
+            // Build and run algoritm
+            auto algorithm = builder.
+              setInputs(f.getCudaPointers()).
+              setCount(count).
+              setImplementation(impl).
+              getAlgorithm(context);
+            algorithm->run();
+
+            // Verify results
+            f.copyToHost();
+            f.checkAllreduceResult();
+          }
+        }
+      });
+  }
+}
+
+TYPED_TEST(CudaAllreduceBuilderTest, TestAsync) {
+  std::vector<enum ::gloo::AllreduceBuilder<TypeParam>::Implementation> impls =
+    {
+      ::gloo::AllreduceBuilder<TypeParam>::HalvingDoubling,
+      ::gloo::AllreduceBuilder<TypeParam>::HalvingDoublingPipelined,
+      ::gloo::AllreduceBuilder<TypeParam>::Ring,
+      ::gloo::AllreduceBuilder<TypeParam>::RingChunked,
+    };
+
+  ::gloo::AllreduceBuilder<TypeParam> builder;
+
+  // Only test with 10 elements; this is not an algorithm implementation test
+  auto count = 10;
+
+  // Works for context size 1 or > 1
+  for (auto size = 1; size <= 2; size++) {
+    this->spawn(size, [&](std::shared_ptr<Context> context) {
+        for (const auto impl : impls) {
+          // Works for 1 or > 1 inputs
+          for (auto inputs = 1; inputs <= 2; inputs++) {
+            CudaFixture<TypeParam> f(context, inputs, count);
+            f.assignValuesAsync();
+
+            // Build and run algoritm
+            auto algorithm = builder.
+              setInputs(f.getCudaPointers()).
+              setStreams(f.getCudaStreams()).
+              setCount(count).
+              setImplementation(impl).
+              getAlgorithm(context);
+            algorithm->run();
+
+            // Verify results
+            f.copyToHost();
+            f.checkAllreduceResult();
+          }
+        }
+      });
+  }
+}
+
+} // namespace
+} // namespace test
+} // namespace gloo


### PR DESCRIPTION
This builder class is an initial stab at moving the decision which
algorithm implementation to use to Gloo. Different machine or network
configurations, or buffer sizes, warrant different implementations.
Hardcoding these decisions over and over in downstream code is not
productive. Instead, we can (eventually) have Gloo make these
decisions for us.

Another benefit of deferring this decision is that we can more easily
choose the optimal implementation in case there is just a single
process with multiple buffers. Downstream code currently has to make a
distinction between single machine and multi machine configurations
and removing this distinction means these code paths can be
simplified.

This commit only contains a builder for Allreduce. The benchmark code
only uses the builder in case it runs an allreduce benchmark and the
current approach otherwise. When builders for the other collectives
are added we should up the benchmark main code as well.