### PR TITLE
Added getDeviceNames helper function to get all IBVerb names

### DIFF
--- a/gloo/transport/ibverbs/device.cc
+++ b/gloo/transport/ibverbs/device.cc
@@ -15,7 +15,6 @@
 
 #include <algorithm>
 #include <array>
-#include <vector>
 
 #include "gloo/common/error.h"
 #include "gloo/common/linux.h"
@@ -29,16 +28,16 @@ namespace ibverbs {
 static const std::chrono::seconds kTimeoutDefault = std::chrono::seconds(30);
 
 // Scope guard for ibverbs device list.
-class ibv_devices {
+class IbvDevices {
  public:
-  ibv_devices() {
+  IbvDevices() {
     list_ = ibv_get_device_list(&size_);
     if (list_ == nullptr) {
       size_ = 0;
     }
   }
 
-  ~ibv_devices() {
+  ~IbvDevices() {
     if (list_ != nullptr) {
       ibv_free_device_list(list_);
     }
@@ -57,10 +56,20 @@ class ibv_devices {
   struct ibv_device** list_;
 };
 
+std::vector<std::string> getDeviceNames() {
+  IbvDevices devices;
+  std::vector<std::string> deviceNames;
+  for (auto i = 0; i < devices.size(); ++i) {
+    deviceNames.push_back(devices[i]->name);
+  }
+  std::sort(deviceNames.begin(), deviceNames.end());
+  return deviceNames;
+}
+
 std::shared_ptr<::gloo::transport::Device> CreateDevice(
     const struct attr& constAttr) {
   struct attr attr = constAttr;
-  ibv_devices devices;
+  IbvDevices devices;
 
   // Default to using the first device if not specified
   if (attr.name.empty()) {

--- a/gloo/transport/ibverbs/device.h
+++ b/gloo/transport/ibverbs/device.h
@@ -11,6 +11,7 @@
 
 #include <atomic>
 #include <thread>
+#include <vector>
 
 #include <infiniband/verbs.h>
 
@@ -31,6 +32,9 @@ struct attr {
   int port;
   int index;
 };
+
+// Helper function that returns the list of IB device names in sorted order
+std::vector<std::string> getDeviceNames();
 
 std::shared_ptr<::gloo::transport::Device> CreateDevice(
     const struct attr&);


### PR DESCRIPTION
Added getDeviceNames as a helper function to get all the IB devices so that we can use it as a lib.

Tested by building 
cmake ../ -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DUSE_MPI=ON -DUSE_CUDA=ON -DUSE_NCCL=ON -DUSE_IBVERBS=ON -DCMAKE_SKIP_BUILD_RPATH=TRUE -DNCCL_ROOT_DIR=$NCCL_ROOT_DIR

and 

Run IB benchmark with success