### PR TITLE
Add optional handling of MPI lifecycle to MPI context

### DIFF
--- a/gloo/mpi/context.h
+++ b/gloo/mpi/context.h
@@ -17,14 +17,35 @@
 namespace gloo {
 namespace mpi {
 
+class MPIScope {
+ public:
+  MPIScope();
+  ~MPIScope();
+};
+
 class Context : public ::gloo::Context {
  public:
+  // This function acquires and holds on to a global MPI scope object.
+  // The MPI scope object calls MPI_Init upon construction and
+  // MPI_Finalize upon destruction. Use this function to create a
+  // context if you want this to be managed by Gloo.
+  static std::shared_ptr<Context> createManaged();
+
+  // This constructor clone the specified MPI common world. Use it if
+  // you are calling MPI_Init and MPI_Finalize yourself.
   explicit Context(const MPI_Comm& comm);
+
   virtual ~Context();
 
   void connectFullMesh(std::shared_ptr<transport::Device>& dev);
 
  protected:
+  // If Gloo is responsible for calling MPI_Init and MPI_Finalize,
+  // this context refers to a singleton initializer. As soon as the
+  // last MPI context is destructed, this initializer is destructed,
+  // and MPI_Finalize will be called.
+  std::shared_ptr<MPIScope> mpiScope_;
+
   MPI_Comm comm_;
 };
 

--- a/gloo/mpi/example/CMakeLists.txt
+++ b/gloo/mpi/example/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(main_managed main_managed.cc)
+target_link_libraries(main_managed gloo)
+add_executable(main_unmanaged main_unmanaged.cc)
+target_link_libraries(main_unmanaged gloo)

--- a/gloo/mpi/example/main_managed.cc
+++ b/gloo/mpi/example/main_managed.cc
@@ -15,16 +15,11 @@
 #include "gloo/allreduce_ring.h"
 
 int main(int argc, char** argv) {
-  int rv;
-
-  rv = MPI_Init(&argc, &argv);
-  assert(rv == MPI_SUCCESS);
-
   // We'll use the TCP transport in this example
   auto dev = gloo::transport::tcp::CreateDevice("localhost");
 
-  // Create Gloo context from MPI communicator
-  auto context = std::make_shared<gloo::mpi::Context>(MPI_COMM_WORLD);
+  // Create Gloo context and delegate management of MPI_Init/MPI_Finalize
+  auto context = gloo::mpi::Context::createManaged();
   context->connectFullMesh(dev);
 
   // Create and run simple allreduce
@@ -33,7 +28,5 @@ int main(int argc, char** argv) {
   allreduce.run();
   std::cout << "Result: " << rank << std::endl;
 
-  rv = MPI_Finalize();
-  assert(rv == MPI_SUCCESS);
   return 0;
 }

--- a/gloo/mpi/example/main_unmanaged.cc
+++ b/gloo/mpi/example/main_unmanaged.cc
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <cassert>
+#include <iostream>
+
+#include "gloo/mpi/context.h"
+#include "gloo/transport/tcp/device.h"
+#include "gloo/allreduce_ring.h"
+
+int main(int argc, char** argv) {
+  int rv;
+
+  rv = MPI_Init(&argc, &argv);
+  assert(rv == MPI_SUCCESS);
+
+  // We'll use the TCP transport in this example
+  auto dev = gloo::transport::tcp::CreateDevice("localhost");
+
+  // Use inner scope to force destruction of context and algorithm
+  {
+    // Create Gloo context from MPI communicator
+    auto context = std::make_shared<gloo::mpi::Context>(MPI_COMM_WORLD);
+    context->connectFullMesh(dev);
+
+    // Create and run simple allreduce
+    int rank = context->rank;
+    gloo::AllreduceRing<int> allreduce(context, {&rank}, 1);
+    allreduce.run();
+    std::cout << "Result: " << rank << std::endl;
+  }
+
+  rv = MPI_Finalize();
+  assert(rv == MPI_SUCCESS);
+  return 0;
+}


### PR DESCRIPTION
Applications that are launched through MPI but only use Gloo directly
shouldn't have to deal with MPI_Init/MPI_Finalize. By using the
createManaged() function on the MPI context, an application can now
defer dealing with MPI_Init and MPI_Finalize to Gloo.