### PR TITLE
Fix missing set device in CUDA test fixture

### DIFF
--- a/gloo/test/cuda_base_test.h
+++ b/gloo/test/cuda_base_test.h
@@ -50,6 +50,7 @@ class CudaFixture : public Fixture<T> {
   void assignValuesAsync() {
     Fixture<T>::assignValues();
     for (auto i = 0; i < cudaSrcs.size(); i++) {
+      CudaDeviceScope scope(cudaStreams[i].getDeviceID());
       // Insert sleep on stream to force to artificially delay the
       // kernel that actually populates the memory to surface
       // synchronization errors.


### PR DESCRIPTION
This caused a mismatch between the device that was set and the stream
used to launch the cudaSleep kernel on.

Thanks to @lukeyeager for spotting this.