### PR TITLE
Set SO_LINGER to avoid TIME_WAIT after close()

### DIFF
--- a/gloo/test/base_test.h
+++ b/gloo/test/base_test.h
@@ -24,6 +24,25 @@
 namespace gloo {
 namespace test {
 
+class Barrier {
+ public:
+  explicit Barrier(std::size_t count) : count_(count) {}
+
+  void wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (--count_ == 0) {
+      cv_.notify_all();
+    } else {
+      cv_.wait(lock, [this] { return count_ == 0; });
+    }
+  }
+
+ private:
+  std::size_t count_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+};
+
 class BaseTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
@@ -59,13 +78,28 @@ class BaseTest : public ::testing::Test {
   void spawn(
       int size,
       std::function<void(std::shared_ptr<Context>)> fn) {
+    Barrier barrier(size);
     spawnThreads(size, [&](int rank) {
         auto context =
           std::make_shared<::gloo::rendezvous::Context>(rank, size);
         if (size > 1) {
           context->connectFullMesh(*store_, device_);
         }
-        fn(std::move(context));
+        fn(context);
+
+        // Since the test suite only deals with threads within a
+        // process, we can cheat and use an in-process barrier to
+        // ensure all threads have finished before explicitly closing
+        // all pairs. Instead of relying on the pair's destructor
+        // closing the underlying connection, we explicitly call
+        // close(). This sets the SO_LINGER socket option (in case of
+        // the tcp transport) to avoid the TIME_WAIT connection state.
+        // This test suite contains many tests and we risk running out
+        // of ports to bind to otherwise.
+        barrier.wait();
+        if (size > 1) {
+          context->closeConnections();
+        }
       });
   }
 


### PR DESCRIPTION
The test suite contains many tests and creates many connections. We've
reached a point where I see the test suite hanging waiting for ports
to listen on to become available, with many connections hanging around
in the TIME_WAIT state. Setting SO_LINGER with a linger value of 0
means that a subsequent call to close(2) sends a RST instead of going
through the normal FIN flow. This is a bit hacky, but now the tests
can run without hanging or fail with bind(2) errors.