### PR TITLE
Fix NCCL collectives with roots

### DIFF
--- a/gloo/cuda_collectives_nccl.h
+++ b/gloo/cuda_collectives_nccl.h
@@ -65,7 +65,7 @@ class CudaLocalNCCLReduce<T, CudaDevicePointer<T> > : public LocalOp<T> {
       reduceOp_ = make_unique<nccl::ReduceOp<T> >(
           toDeviceElements(streams, devicePtrs, offset, count),
           fn,
-          devicePtrs[root].getDeviceID());
+          root);
     }
   }
 
@@ -106,7 +106,7 @@ class CudaLocalNCCLReduce<T, CudaHostPointer<T> > : public LocalOp<T> {
       reduceOp_ = make_unique<nccl::ReduceOp<T> >(
           toDeviceElements(streams, devicePtrs, offset, count),
           fn,
-          devicePtrs[root_].getDeviceID());
+          root_);
     }
   }
 
@@ -166,7 +166,7 @@ class CudaLocalNCCLBroadcast<T, CudaDevicePointer<T> > : public LocalOp<T> {
     if (devicePtrs.size() > 1) {
       broadcastOp_ = make_unique<nccl::BroadcastOp<T> >(
           toDeviceElements(streams, devicePtrs, offset, count),
-          devicePtrs[root].getDeviceID());
+          root);
     }
   }
 
@@ -205,7 +205,7 @@ class CudaLocalNCCLBroadcast<T, CudaHostPointer<T> > : public LocalOp<T> {
     if (devicePtrs.size() > 1) {
       broadcastOp_ = make_unique<nccl::BroadcastOp<T> >(
           toDeviceElements(streams, devicePtrs, offset, count),
-          devicePtrs[root_].getDeviceID());
+          root_);
     }
   }
 


### PR DESCRIPTION
Need to pass the NCCL rank as root instead of the root device ordinal.

Example of the previous issue: Imagine a 2 process, 4 GPU / process run with devices `0 : {0,1,2,3}, 1 : {4,5,6,7}`. Reduce on process 1 should pass `rank=0` whereas previously it would pass `rank=device[0]=4`, causing an error.