### PR TITLE
workaround nvcc 7.5 bug by moving some header definitions out of .cu paths

### DIFF
--- a/gloo/common/CMakeLists.txt
+++ b/gloo/common/CMakeLists.txt
@@ -7,6 +7,7 @@ set(GLOO_COMMON_HDRS
   "${CMAKE_CURRENT_SOURCE_DIR}/common.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/error.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/linux.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/linux_devices.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/logging.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/string.h"
   )

--- a/gloo/common/linux.cc
+++ b/gloo/common/linux.cc
@@ -8,6 +8,7 @@
  */
 
 #include "gloo/common/linux.h"
+#include "gloo/common/linux_devices.h"
 
 #include <dirent.h>
 #include <errno.h>

--- a/gloo/common/linux.h
+++ b/gloo/common/linux.h
@@ -22,12 +22,6 @@ struct PCIClassMatch {
   int mask;
 };
 
-// Matches 03 (Display controller), 02 (3D controller)
-const auto kPCIClass3D = PCIClassMatch{0x030200, 0xffff00};
-
-// Matches 02 (Network controller), both Ethernet (00) and InfiniBand (07)
-const auto kPCIClassNetwork = PCIClassMatch{0x020000, 0xff0000};
-
 std::vector<std::string> pciDevices(PCIClassMatch);
 
 int pciDistance(const std::string& a, const std::string& b);

--- a/gloo/common/linux_devices.h
+++ b/gloo/common/linux_devices.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "linux.h"
+
+namespace gloo {
+
+// We defined these structs in a separate header and dont include 
+// it from and .cu files because of an NVCC 7.5 bug
+
+// Matches 03 (Display controller), 02 (3D controller)
+const auto kPCIClass3D = PCIClassMatch{0x030200, 0xffff00};
+
+// Matches 02 (Network controller), both Ethernet (00) and InfiniBand (07)
+const auto kPCIClassNetwork = PCIClassMatch{0x020000, 0xff0000};
+
+} // namespace gloo

--- a/gloo/test/linux_test.cc
+++ b/gloo/test/linux_test.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "gloo/common/linux.h"
+#include "gloo/common/linux_devices.h"
 #include "gloo/test/base_test.h"
 
 namespace gloo {


### PR DESCRIPTION
Right now even with a supported GCC version, NVCC 7.5 gives this error when compiling gloo:

```
/opt/conda/conda-bld/pytorch_1510762952877/work/torch/lib/gloo/gloo/common/linux.h:26:26: error: ‘__T0’ was not declared in this scope
 const auto kPCIClass3D = PCIClassMatch{0x030200, 0xffff00};
                          ^
/opt/conda/conda-bld/pytorch_1510762952877/work/torch/lib/gloo/gloo/common/linux.h:29:31: error: ‘__T0’ was not declared in this scope
 const auto kPCIClassNetwork = PCIClassMatch{0x020000, 0xff0000};
                               ^
/opt/conda/conda-bld/pytorch_1510762952877/work/torch/lib/gloo/gloo/common/linux.h:26:26: error: ‘__T0’ was not declared in this scope
 const auto kPCIClass3D = PCIClassMatch{0x030200, 0xffff00};
                          ^
/opt/conda/conda-bld/pytorch_1510762952877/work/torch/lib/gloo/gloo/common/linux.h:29:31: error: ‘__T0’ was not declared in this scope
 const auto kPCIClassNetwork = PCIClassMatch{0x020000, 0xff0000};
                               ^
CMake Error at gloo_cuda_generated_cuda_private.cu.o.cmake:263 (message):
  Error generating file
  /opt/conda/conda-bld/pytorch_1510762952877/work/torch/lib/build/gloo/gloo/CMakeFiles/gloo_cuda.dir//./gloo_cuda_generated_cuda_private.cu.o
```

This is a workaround to avoid the kPCIClassNetwork and kPCIClass3D variables in the `.cu` file paths.