### PR TITLE
NCCL2 multinode allreduce

### DIFF
--- a/gloo/CMakeLists.txt
+++ b/gloo/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND GLOO_HDRS
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_halving_doubling.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_bcube.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_local.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cuda_allreduce_nccl2.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_ring.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_ring_chunked.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/barrier.h"

--- a/gloo/cuda_allreduce_nccl2.cc
+++ b/gloo/cuda_allreduce_nccl2.cc
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "gloo/cuda_allreduce_nccl2.h"
+
+#include "gloo/broadcast_one_to_all.h"
+#include "gloo/cuda_private.h"
+
+#include <unordered_map>
+
+namespace gloo {
+
+namespace {
+
+// Creating NCCL communicators is expensive. So we cache and reuse them.
+static std::shared_ptr<NCCLCommList> getCachedCommList(
+    const std::shared_ptr<Context>& context,
+    const std::vector<int> localDevices)
+{
+  // per-process cache of communicators
+  static std::unordered_map<std::string, std::shared_ptr<NCCLCommList> >
+    commLists;
+
+  // generate key
+  const int numDevices = localDevices.size();
+  std::string key = std::to_string(context->size) + ' ' +
+    std::to_string(context->rank);
+  for (auto i = 0; i < numDevices; ++i) {
+    key += ' ' + std::to_string(localDevices[i]);
+  }
+
+  // globally lock here for 2 reasons:
+  // 1. Only one set of communicators should be created, make sure we
+  //    don't get multiple threads trying to do it at the same time.
+  // 2. Prevent concurrent NCCL initialisations - shouldn't be an issue,
+  //    but might as well be cautious.
+  {
+    std::lock_guard<std::mutex> lock(CudaShared::getMutex());
+
+    if (!commLists[key]) {
+      commLists[key] = std::make_shared<NCCLCommList>(context, localDevices);
+    }
+  }
+
+  const auto commList = commLists[key];
+  GLOO_ENFORCE_NE(commList.get(), (void*)nullptr);
+  return commList;
+}
+
+
+// Cache streams across algorithms unless user passes streams
+//  - this enforces an ordering on NCCL calls from within gloo
+//    and should reduce possbility of deadlocks
+static std::shared_ptr<NCCLStreamList> getCachedStreamList(
+    const std::shared_ptr<Context>& context,
+    const std::vector<int> localDevices) {
+  // per-process cache of streams
+  static std::unordered_map<std::string, std::shared_ptr<NCCLStreamList> >
+    streamLists;
+
+  // generate key
+  const int numDevices = localDevices.size();
+  std::string key = std::to_string(context->size) + ' ' +
+    std::to_string(context->rank);
+  for (auto i = 0; i < numDevices; ++i) {
+    key += ' ' + std::to_string(localDevices[i]);
+  }
+
+  // globally lock here
+  // Only one set of streams should be created, make sure we
+  // don't get multiple threads trying to do it at the same time.
+  {
+    std::lock_guard<std::mutex> lock(CudaShared::getMutex());
+
+    if (!streamLists[key]) {
+      streamLists[key] = std::make_shared<NCCLStreamList>(context, localDevices);
+    }
+  }
+
+  const auto streamList = streamLists[key];
+  GLOO_ENFORCE_NE(streamList.get(), (void*)nullptr);
+  return streamList;
+}
+
+} // namespace
+
+// Create a set of NCCL communicators for caching.
+// NB. This constructor will only ever be called from within a mutex,
+//     so no need to lock inside for any reason.
+NCCLCommList::NCCLCommList(const std::shared_ptr<Context>& context,
+    const std::vector<int> localDevices) {
+  // generate unique ID on root node
+  ncclUniqueId *id = new ncclUniqueId;
+  std::vector<char*> ids;
+  ids.push_back(id->internal);
+  if (context->rank == 0) {
+    NCCL_CHECK(ncclGetUniqueId(id));
+  }
+
+  // broadcast ID to other nodes
+  BroadcastOneToAll<char>(context, ids, NCCL_UNIQUE_ID_BYTES).run();
+
+  // create comms
+  // FIXME currently, we assume all ranks use the same number of devices
+  const int numDevices = localDevices.size();
+	// num_ranks * num_devices_per_rank
+  const int ncclSize = context->size * numDevices;
+  // rank_id * num_devices_per_rank
+  const int ncclRankStart = context->rank * numDevices;
+
+  comms.reserve(numDevices);
+  {
+    NCCL_CHECK(ncclGroupStart());
+    for (auto i = 0; i < numDevices; ++i) {
+      NCCL_CHECK(ncclCommInitRank(&comms[i], ncclSize, *id,
+                 ncclRankStart + i));
+    }
+    NCCL_CHECK(ncclGroupEnd());
+  }
+}
+
+NCCLCommList::~NCCLCommList() {
+  for (auto i = 0; i < comms.size(); ++i) {
+    // Shouldn't be necessary, perhaps overly cautious
+    std::lock_guard<std::mutex> lock(CudaShared::getMutex());
+    ncclCommDestroy(comms[i]);
+  }
+}
+
+// NB. Only called from within a mutexed region
+NCCLStreamList::NCCLStreamList(const std::shared_ptr<Context>& context,
+                               const std::vector<int> localDevices) {
+  const int size = localDevices.size();
+
+  streams.clear();
+
+  for (auto i=0; i<size; ++i) {
+    streams.push_back(CudaStream(localDevices[i]));
+  }
+}
+
+template <typename T>
+CudaAllreduceNccl2<T>::CudaAllreduceNccl2(
+  const std::shared_ptr<Context>& context,
+  const std::vector<T*>& ptrs,
+  const int count,
+  const std::vector<cudaStream_t>& streams)
+    : Algorithm(context),
+      count_(count),
+      bytes_(count_ * sizeof(T)),
+      synchronizeDeviceOutputs_(streams.size() == 0),
+      fn_(CudaReductionFunction<T>::sum) {
+
+  // translate input pointers into gloo structures
+  std::vector<int> localDevices(ptrs.size());
+  for (auto i = 0; i < ptrs.size(); i++) {
+    auto ptr = CudaDevicePointer<T>::create(ptrs[i], count_);
+    devicePtrs_.push_back(std::move(ptr));
+		localDevices[i] = devicePtrs_[i].getDeviceID();
+  }
+
+  // get / initialize cached communicators (thread-safe)
+	commList_ = getCachedCommList(context, localDevices);
+
+  // setup what streams we're going to use.
+  // Honour what the user passes, or generate some streams that we'll create and cache;
+  auto newStream = true;
+  if (streams.size() > 0) {
+    GLOO_ENFORCE_EQ(streams.size(), ptrs.size());
+    newStream = false;
+  }
+  streams_.reserve(ptrs.size());
+
+  if (!newStream) {
+    for (auto i=0; i< devicePtrs_.size(); ++i) {
+      streams_.push_back(CudaStream(devicePtrs_[i].getDeviceID(), streams[i]));
+    }
+  } else {
+    // get / initialize cached streams (thread-safe)
+    streamList_ = getCachedStreamList(context, localDevices);
+
+    // convert cached streams to local streams
+    for (auto i=0; i < devicePtrs_.size(); ++i) {
+      streams_.push_back(CudaStream(devicePtrs_[i].getDeviceID(), *streamList_->streams[i]));
+    }
+  }
+
+  // TODO: necessary?
+  barrier_.reset(new gloo::BarrierAllToAll(context));
+}
+
+template <typename T>
+void CudaAllreduceNccl2<T>::run() {
+    // abundance of caution again
+    barrier_->run();
+    {
+      // Need to lock out both other NCCL calls and anything that could
+      // cause deadlocks.
+      std::lock_guard<std::mutex> lock(CudaShared::getMutex());
+      NCCL_CHECK(ncclGroupStart());
+      for (int i=0; i<devicePtrs_.size(); i++) {
+        NCCL_CHECK(ncclAllReduce(
+              (const void*)(*devicePtrs_[i]), (void*)(*devicePtrs_[i]),
+              count_, nccl::ncclTypeWrapper<T>::type, ncclSum, commList_->comms[i],
+              *streams_[i]));
+      }
+      NCCL_CHECK(ncclGroupEnd());
+    }
+
+  // Now that we've returned from NCCL, perform stream syncs
+  for (int i=0; i<devicePtrs_.size(); i++) {
+    CUDA_CHECK(cudaStreamSynchronize(*streams_[i]));
+  }
+}
+
+// Instantiate templates
+#define INSTANTIATE_TEMPLATE(T)                                         \
+template class CudaAllreduceNccl2<T>;
+
+INSTANTIATE_TEMPLATE(int8_t);
+INSTANTIATE_TEMPLATE(int32_t);
+INSTANTIATE_TEMPLATE(int64_t);
+INSTANTIATE_TEMPLATE(uint64_t);
+INSTANTIATE_TEMPLATE(float);
+INSTANTIATE_TEMPLATE(double);
+INSTANTIATE_TEMPLATE(float16);
+
+} // namespace gloo

--- a/gloo/cuda_allreduce_nccl2.cc
+++ b/gloo/cuda_allreduce_nccl2.cc
@@ -1,6 +1,8 @@
 /**
  * Copyright (c) 2017-present, Facebook, Inc.
  * All rights reserved.
+ * Copyright (c) 2017-present, NVIDIA CORPORATION,
+ * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/gloo/cuda_allreduce_nccl2.h
+++ b/gloo/cuda_allreduce_nccl2.h
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include "gloo/algorithm.h"
+#include "gloo/barrier_all_to_all.h"
+#include "gloo/cuda.h"
+#include "gloo/cuda_workspace.h"
+#include "gloo/nccl/nccl.h"
+
+#include <unordered_map>
+
+namespace gloo {
+
+class NCCLCommList {
+ public:
+  NCCLCommList(const std::shared_ptr<Context>& context,
+      const std::vector<int> localDevices);
+  ~NCCLCommList();
+  std::vector<ncclComm_t> comms;
+};
+
+class NCCLStreamList {
+ public:
+  NCCLStreamList(const std::shared_ptr<Context>& context,
+      const std::vector<int> localDevices);
+
+  std::vector<CudaStream> streams;
+};
+
+template <typename T>
+class CudaAllreduceNccl2 : public Algorithm {
+ public:
+  CudaAllreduceNccl2(
+      const std::shared_ptr<Context>& context,
+      const std::vector<T*>& ptrs,
+      const int count,
+      const std::vector<cudaStream_t>& streams = std::vector<cudaStream_t>());
+
+  virtual void run() override;
+
+ protected:
+  std::vector<CudaDevicePointer<T> > devicePtrs_;
+  std::vector<CudaStream> streams_;
+  CudaStream* scratchStream_;
+
+  std::shared_ptr<NCCLCommList> commList_;
+  std::shared_ptr<NCCLStreamList> streamList_;
+
+  const int count_;
+  const int bytes_;
+  const bool synchronizeDeviceOutputs_;
+  const CudaReductionFunction<T>* fn_;
+
+  std::unique_ptr<LocalOp<T> > localReduceOp_;
+  std::unique_ptr<LocalOp<T> > localBroadcastOp_;
+
+  std::unique_ptr<transport::Buffer> sendDataBuf_;
+  std::unique_ptr<transport::Buffer> recvDataBuf_;
+
+  int dummy_;
+  std::unique_ptr<transport::Buffer> sendNotificationBuf_;
+  std::unique_ptr<transport::Buffer> recvNotificationBuf_;
+
+  int rank_;
+  std::unique_ptr<gloo::BarrierAllToAll> barrier_;
+};
+
+} // namespace gloo

--- a/gloo/cuda_allreduce_nccl2.h
+++ b/gloo/cuda_allreduce_nccl2.h
@@ -51,7 +51,6 @@ class CudaAllreduceNccl2 : public Algorithm {
  protected:
   std::vector<CudaDevicePointer<T> > devicePtrs_;
   std::vector<CudaStream> streams_;
-  CudaStream* scratchStream_;
 
   std::shared_ptr<NCCLCommList> commList_;
   std::shared_ptr<NCCLStreamList> streamList_;
@@ -60,16 +59,6 @@ class CudaAllreduceNccl2 : public Algorithm {
   const int bytes_;
   const bool synchronizeDeviceOutputs_;
   const CudaReductionFunction<T>* fn_;
-
-  std::unique_ptr<LocalOp<T> > localReduceOp_;
-  std::unique_ptr<LocalOp<T> > localBroadcastOp_;
-
-  std::unique_ptr<transport::Buffer> sendDataBuf_;
-  std::unique_ptr<transport::Buffer> recvDataBuf_;
-
-  int dummy_;
-  std::unique_ptr<transport::Buffer> sendNotificationBuf_;
-  std::unique_ptr<transport::Buffer> recvNotificationBuf_;
 
   int rank_;
   std::unique_ptr<gloo::BarrierAllToAll> barrier_;

--- a/gloo/cuda_allreduce_nccl2.h
+++ b/gloo/cuda_allreduce_nccl2.h
@@ -1,6 +1,8 @@
 /**
  * Copyright (c) 2017-present, Facebook, Inc.
  * All rights reserved.
+ * Copyright (c) 2017-present, NVIDIA CORPORATION,
+ * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/gloo/nccl/nccl.cu
+++ b/gloo/nccl/nccl.cu
@@ -119,52 +119,6 @@ std::string NCCLExecution<T>::getKey() const {
   }
   return result;
 }
-
-template <typename T>
-class ncclTypeWrapper;
-
-template <>
-class ncclTypeWrapper<int8_t> {
- public:
-  static const ncclDataType_t type = ncclChar;
-};
-
-template <>
-class ncclTypeWrapper<int32_t> {
- public:
-  static const ncclDataType_t type = ncclInt;
-};
-
-template <>
-class ncclTypeWrapper<int64_t> {
- public:
-  static const ncclDataType_t type = ncclInt64;
-};
-
-template <>
-class ncclTypeWrapper<uint64_t> {
- public:
-  static const ncclDataType_t type = ncclUint64;
-};
-
-template <>
-class ncclTypeWrapper<float16> {
- public:
-  static const ncclDataType_t type = ncclHalf;
-};
-
-template <>
-class ncclTypeWrapper<float> {
- public:
-  static const ncclDataType_t type = ncclFloat;
-};
-
-template <>
-class ncclTypeWrapper<double> {
- public:
-  static const ncclDataType_t type = ncclDouble;
-};
-
 template <typename T>
 NCCLOp<T>::NCCLOp(NCCLExecution<T>&& execution)
     : execution_(std::move(execution)), context_(getNcclContext(execution_)) {}

--- a/gloo/nccl/nccl.h
+++ b/gloo/nccl/nccl.h
@@ -41,6 +41,51 @@ namespace nccl {
       ((NCCL_MINOR == minor) && (NCCL_PATCH >= patch)) )))
 
 template <typename T>
+class ncclTypeWrapper;
+
+template <>
+class ncclTypeWrapper<int8_t> {
+ public:
+  static const ncclDataType_t type = ncclChar;
+};
+
+template <>
+class ncclTypeWrapper<int32_t> {
+ public:
+  static const ncclDataType_t type = ncclInt;
+};
+
+template <>
+class ncclTypeWrapper<int64_t> {
+ public:
+  static const ncclDataType_t type = ncclInt64;
+};
+
+template <>
+class ncclTypeWrapper<uint64_t> {
+ public:
+  static const ncclDataType_t type = ncclUint64;
+};
+
+template <>
+class ncclTypeWrapper<float16> {
+ public:
+  static const ncclDataType_t type = ncclHalf;
+};
+
+template <>
+class ncclTypeWrapper<float> {
+ public:
+  static const ncclDataType_t type = ncclFloat;
+};
+
+template <>
+class ncclTypeWrapper<double> {
+ public:
+  static const ncclDataType_t type = ncclDouble;
+};
+
+template <typename T>
 struct NCCLElement {
   NCCLElement(
       CudaDevicePointer<T> srcParam,


### PR DESCRIPTION
This is based on work originally done by @lukeyeager, and is a first look at integration of the multi-node capabilities of NCCL2 into gloo as a new `Algorithm`.

Notes:
1. We cache created NCCL communicators in order to reduce both startup time and open-file limits that can be hit otherwise
2. Unless users pass streams, we create and re-use a set of streams for all reduction calls through NCCL2. This enforces an ordering of calls, and should alleviate deadlock concerns.
3. Currently the algorithm is synchronous with respect to the host - `cudaStreamSynchronize` is called at the end before returning. @pietern to comment.
4. Some re-arrangement of code needed to be done in `gloo/nccl/nccl.{h,cu}` in order to facilitate the work