### PR TITLE
Fix include of prefix_store.h

### DIFF
--- a/gloo/benchmark/runner.cc
+++ b/gloo/benchmark/runner.cc
@@ -18,10 +18,10 @@
 #include "gloo/common/logging.h"
 #include "gloo/rendezvous/context.h"
 #include "gloo/rendezvous/file_store.h"
+#include "gloo/rendezvous/prefix_store.h"
 #include "gloo/transport/device.h"
 
 #if GLOO_USE_REDIS
-#include "gloo/rendezvous/prefix_store.h"
 #include "gloo/rendezvous/redis_store.h"
 #endif
 


### PR DESCRIPTION
This include was conditional on GLOO_USE_REDIS being defined, but is
required by the file store as of 03833bb.