### PR TITLE
Add missing array include

### DIFF
--- a/gloo/common/linux.cc
+++ b/gloo/common/linux.cc
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <fstream>
 #include <map>
 #include <mutex>


### PR DESCRIPTION
This works in versions of stl where an include of <algorithm> ends up
eventually including <array>. But it looks like this is no longer the
case in newer versions of stl.

This fixes #113.