### PR TITLE
Remove googletest submodule

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -16,6 +16,7 @@ fi
 
 cmake .. \
     -DCMAKE_VERBOSE_MAKEFILE=ON \
+    -DGTEST_ROOT=/tmp/googletest \
     -DBUILD_TEST=ON \
     -DBUILD_BENCHMARK=ON \
     ${CMAKE_ARGS}

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -8,6 +8,17 @@ sudo apt-get install -y \
     libhiredis-dev \
     libibverbs-dev
 
+# Install Google Test
+tag=release-1.8.0
+pushd /tmp
+curl -Ls "https://github.com/google/googletest/archive/${tag}.tar.gz" | tar -zxvf -
+cd "googletest-${tag}"
+mkdir -p build
+cd build
+cmake ../ -DCMAKE_INSTALL_PREFIX=/tmp/googletest
+make install
+popd
+
 if [[ "${BUILD_CUDA}" == 'ON' ]]; then
   ################
   # Install CUDA #

--- a/README.md
+++ b/README.md
@@ -49,27 +49,43 @@ You can build Gloo using CMake.
 Since it is a library, it is most convenient to vendor it in your own
 project and include the project root in your own CMake configuration.
 
-For standalone builds (e.g. to run tests or benchmarks), first check
-out the submodules in `third-party` by running:
+### Test
 
-```shell
-git submodule update --init
+Building the tests requires Google Test version 1.8 or higher. On
+Ubuntu, this version ships with version 17.10 and up. If you run an
+older version, you'll have to install Google Test yourself, and set
+the `GTEST_ROOT` CMake variable.
+
+To build the tests, run:
+
+``` shell
+mkdir -p build
+cd build
+cmake ../ -DBUILD_TEST=1 -DGTEST_ROOT=/some/path (if using custom install)
+make
+ls -l gloo/test/gloo_test*
 ```
 
-Also install the dependencies required by the benchmark tool. On
+To test the CUDA algorithms, specify `USE_CUDA=ON` as well, and the
+CUDA tests are built at `gloo/test/gloo_test_cuda`.
+
+### Benchmark
+
+
+First install the dependencies required by the benchmark tool. On
 Ubuntu, you can do so by running:
 
 ``` shell
 sudo apt-get install -y libhiredis-dev libeigen3-dev
 ```
 
-Then, to build:
+Then build the benchmark, run:
 
 ``` shell
 mkdir build
 cd build
-cmake ../ -DBUILD_TEST=1 -DBUILD_BENCHMARK=1
-ls -l gloo/{test,benchmark}/{test,benchmark}
+cmake ../ -DBUILD_BENCHMARK=1
+ls -l gloo/benchmark/benchmark
 ```
 
 ## Benchmarking

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -67,18 +67,16 @@ endif()
 
 # Make sure we can find googletest if building the tests
 if(BUILD_TEST)
-  set(GOOGLETEST_ROOT_DIR "${PROJECT_SOURCE_DIR}/third-party/googletest")
-  if (EXISTS "${GOOGLETEST_ROOT_DIR}")
-    set(BUILD_GTEST ON CACHE INTERNAL "Builds the googletest subproject")
-    set(BUILD_GMOCK OFF CACHE INTERNAL "Builds the googlemock subproject")
-    add_subdirectory(third-party/googletest)
-
-    # Explicitly add googletest include path.
-    # If this is not done, the include path is not passed to
-    # nvcc for CUDA sources for some reason...
-    include_directories(SYSTEM "${GOOGLETEST_ROOT_DIR}/googletest/include")
-  else()
-    message(FATAL_ERROR "Could not find googletest; cannot compile tests")
+  # If the gtest target is already defined, we assume upstream knows
+  # what they are doing and the version is new enough.
+  if(NOT TARGET gtest)
+    find_package(GTest REQUIRED)
+    if(NOT GTEST_FOUND)
+      message(FATAL_ERROR "Could not find googletest; cannot compile tests")
+    endif()
+    add_library(gtest INTERFACE)
+    target_include_directories(gtest INTERFACE ${GTEST_INCLUDE_DIRS})
+    target_link_libraries(gtest INTERFACE ${GTEST_LIBRARIES})
   endif()
 endif()
 

--- a/gloo/test/CMakeLists.txt
+++ b/gloo/test/CMakeLists.txt
@@ -8,8 +8,8 @@ set(GLOO_TEST_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/main.cc"
   )
 
-add_executable(test ${GLOO_TEST_SRCS})
-target_link_libraries(test gloo gloo_builder gtest)
+add_executable(gloo_test ${GLOO_TEST_SRCS})
+target_link_libraries(gloo_test gloo gloo_builder gtest)
 
 if(USE_CUDA)
   set(GLOO_TEST_CUDA_SRCS
@@ -21,6 +21,6 @@ if(USE_CUDA)
     "${CMAKE_CURRENT_SOURCE_DIR}/main.cc"
     )
 
-  cuda_add_executable(test_cuda ${GLOO_TEST_CUDA_SRCS})
-  target_link_libraries(test_cuda gloo_cuda gloo_builder gtest)
+  cuda_add_executable(gloo_test_cuda ${GLOO_TEST_CUDA_SRCS})
+  target_link_libraries(gloo_test_cuda gloo_cuda gloo_builder gtest)
 endif()


### PR DESCRIPTION
We can assume it is either installed on the system, or is built as part
of an upstream CMake project and defines the gtest target.

This change also prefixes the test binaries with "gloo_" to avoid
conflicts with the special CMake target name "test".