### PR TITLE
Add sample CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Greeting
+          command: echo Hello, world.
+      - run:
+          name: Print the Current Time
+          command: date


### PR DESCRIPTION
It appears a sample config is needed to finish configuring CircleCI.

Once enabled it can be changed to run the actual build and tests.