### PR TITLE
Bugfix in CudaBroadcastOneToAll

### DIFF
--- a/gloo/cuda_broadcast_one_to_all.cc
+++ b/gloo/cuda_broadcast_one_to_all.cc
@@ -81,7 +81,12 @@ CudaBroadcastOneToAll<T, W>::CudaBroadcastOneToAll(
   // Setup local broadcast if needed
   if (devicePtrs_.size() > 1) {
     localBroadcastOp_ =
-      cudaDeviceBroadcast(streams_, devicePtrs_, devicePtrs_[0], 0, count_);
+      cudaDeviceBroadcast(
+          streams_,
+          devicePtrs_,
+          devicePtrs_[rootPointerRank],
+          0,
+          count_);
   }
 }
 


### PR DESCRIPTION
When passing multiple input buffers and using a non-default root pointer
did not work; it would always use the first pointer as source.