### PR TITLE
define SPEED_UNKNOWN for compilation with anaconda compilers

### DIFF
--- a/gloo/common/linux.cc
+++ b/gloo/common/linux.cc
@@ -32,7 +32,9 @@
 #include "gloo/common/logging.h"
 
 #ifndef SPEED_UNKNOWN
-/* some platforms doesn't define speed unknown in headers we included. */
+/* SPEED_UNKOWN is sometimes undefined, c.f.
+ * https://github.com/facebookincubator/gloo/pull/127
+ */
 #define SPEED_UNKNOWN 0
 #endif
 

--- a/gloo/common/linux.cc
+++ b/gloo/common/linux.cc
@@ -31,6 +31,11 @@
 
 #include "gloo/common/logging.h"
 
+#ifndef SPEED_UNKNOWN
+/* some platforms doesn't define speed unknown in headers we included. */
+#define SPEED_UNKNOWN 0
+#endif
+
 namespace gloo {
 
 const std::set<std::string>& kernelModules() {


### PR DESCRIPTION
When compiling torch with anaconda compilers I ran into this error about SPEED_UNKNOWN undefined:
 
https://github.com/pytorch/pytorch/issues/4499

I couldn't find the proper header to include -- even if found it is likely not portable.
Given that not too many people outside kernel uses this macro (gloo is one of the few results googling with 'SPEED_KNOWN'), it is
probably a good idea to define it if it is not defined on the system.

Note that the comment on torch set the macro to -1.

The correct value appears to be 0, see e.g. this commit to the kernel:
https://patchwork.kernel.org/patch/9573661/