### PR TITLE
fix install path for config.h

### DIFF
--- a/gloo/CMakeLists.txt
+++ b/gloo/CMakeLists.txt
@@ -111,7 +111,7 @@ if(GLOO_INSTALL)
     install(TARGETS gloo_cuda EXPORT GlooTargets
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
   endif()
-  install(FILES ${CMAKE_BINARY_DIR}/gloo/config.h
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include/gloo)
   foreach(HEADER ${GLOO_HDRS})
     string(REGEX MATCH "(.*)[/\\]" DIR ${HEADER})


### PR DESCRIPTION
needed for building and installing directly from caffe2 cmake