### PR TITLE
Be more explicit in GLOO_ENFORCE (for GCC 8)

### DIFF
--- a/gloo/cuda_collectives_native.h
+++ b/gloo/cuda_collectives_native.h
@@ -36,7 +36,7 @@ class CudaLocalNativeReduce : public LocalOp<T> {
         numPtrs_(devicePtrs.size()),
         steps_(log2(numPtrs_)) {
     // Only works with power-of-2 number of pointers
-    GLOO_ENFORCE(1 << steps_, streams.size(), "Not power of two");
+    GLOO_ENFORCE((1 << steps_) != 0, streams.size(), "Not power of two");
 
     // Incorporate offset/count into devicePtrs
     devicePtrs_.reserve(devicePtrs.size());
@@ -164,7 +164,7 @@ class CudaLocalNativeBroadcast : public LocalOp<T> {
         numPtrs_(devicePtrs.size()),
         steps_(log2(numPtrs_)) {
     // Only works with power-of-2 number of pointers
-    GLOO_ENFORCE(1 << steps_, streams.size(), "Not power of two");
+    GLOO_ENFORCE((1 << steps_) != 0, streams.size(), "Not power of two");
 
     // Incorporate offset/count into devicePtrs
     devicePtrs_.reserve(devicePtrs.size());


### PR DESCRIPTION
Summary:
Adapt Caffe 2 to platform007 (gcc 8):
* gcc 8 + nvcc template symbol lookup (D9319742):
context_.template CopySameDevice<T> ==> this->context_.template CopySameDevice<T>
* New gcc 8 warning (error):
  * -Werror=sizeof-pointer-div
  * Unnecessary parenthesis

Differential Revision: D10045844
