### PR TITLE
Support offset/length arguments for send/recv

### DIFF
--- a/gloo/test/send_recv_test.cc
+++ b/gloo/test/send_recv_test.cc
@@ -80,6 +80,60 @@ TEST_P(SendRecvTest, AllToAll) {
     });
 }
 
+TEST_P(SendRecvTest, AllToAllOffset) {
+  auto contextSize = std::get<0>(GetParam());
+  auto dataSize = std::get<1>(GetParam());
+
+  spawn(contextSize, [&](std::shared_ptr<Context> context) {
+      auto elementSize = sizeof(int);
+      std::vector<int> input(contextSize);
+      std::vector<int> output(contextSize);
+      auto inputBuffer = context->createUnboundBuffer(
+          input.data(), input.size() * elementSize);
+      auto outputBuffer = context->createUnboundBuffer(
+          output.data(), output.size() * elementSize);
+
+      // Initialize
+      for (auto i = 0; i < context->size; i++) {
+        input[i] = i;
+        output[i] = -1;
+      }
+
+      // Send a message with the local rank to every other rank
+      for (auto i = 0; i < context->size; i++) {
+        if (i == context->rank) {
+          continue;
+        }
+        inputBuffer->send(i, 0, context->rank * elementSize, elementSize);
+      }
+
+      // Receive message from every other rank
+      for (auto i = 0; i < context->size; i++) {
+        if (i == context->rank) {
+          continue;
+        }
+        outputBuffer->recv(i, 0, i * elementSize, elementSize);
+      }
+
+      // Wait for send and recv to complete
+      for (auto i = 0; i < context->size; i++) {
+        if (i == context->rank) {
+          continue;
+        }
+        inputBuffer->waitSend();
+        outputBuffer->waitRecv();
+      }
+
+      // Verify output
+      for (auto i = 0; i < context->size; i++) {
+        if (i == context->rank) {
+          continue;
+        }
+        ASSERT_EQ(i, output[i]) << "Mismatch at index " << i;
+      }
+    });
+}
+
 TEST_P(SendRecvTest, RecvFromAny) {
   auto contextSize = std::get<0>(GetParam());
   auto dataSize = std::get<1>(GetParam());
@@ -104,6 +158,50 @@ TEST_P(SendRecvTest, RecvFromAny) {
           buf->recv(ranks, slot);
           buf->waitRecv(&srcRank);
           outputData.insert(tmp);
+          outputRanks.insert(srcRank);
+        }
+
+        // Verify result
+        for (auto i = 1; i < context->size; i++) {
+          ASSERT_EQ(1, outputData.count(i)) << "Missing output " << i;
+          ASSERT_EQ(1, outputRanks.count(i)) << "Missing rank " << i;
+        }
+      } else {
+        // Send to rank 0
+        int tmp = context->rank;
+        auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
+        buf->send(0, slot);
+        buf->waitSend();
+      }
+    });
+}
+
+TEST_P(SendRecvTest, RecvFromAnyOffset) {
+  auto contextSize = std::get<0>(GetParam());
+  auto dataSize = std::get<1>(GetParam());
+
+  spawn(contextSize, [&](std::shared_ptr<Context> context) {
+      auto elementSize = sizeof(int);
+      constexpr uint64_t slot = 0x1337;
+      if (context->rank == 0) {
+        std::unordered_set<int> outputData;
+        std::unordered_set<int> outputRanks;
+        std::array<int, 2> tmp;
+        auto buf =
+            context->createUnboundBuffer(tmp.data(), tmp.size() * elementSize);
+
+        // Compile vector of ranks to receive from
+        std::vector<int> ranks;
+        for (auto i = 1; i < context->size; i++) {
+          ranks.push_back(i);
+        }
+
+        // Receive from N-1 peers
+        for (auto i = 1; i < context->size; i++) {
+          int srcRank = -1;
+          buf->recv(ranks, slot, (i % tmp.size()) * elementSize, elementSize);
+          buf->waitRecv(&srcRank);
+          outputData.insert(tmp[i % tmp.size()]);
           outputRanks.insert(srcRank);
         }
 

--- a/gloo/transport/ibverbs/pair.cc
+++ b/gloo/transport/ibverbs/pair.cc
@@ -328,13 +328,13 @@ Pair::createRecvBuffer(int slot, void* ptr, size_t size) {
 }
 
 // Send from the specified buffer to remote side of pair.
-void Pair::send(transport::UnboundBuffer* tbuf, uint64_t slot) {
+void Pair::send(transport::UnboundBuffer* tbuf, uint64_t slot, size_t offset, size_t nbytes) {
   GLOO_THROW_INVALID_OPERATION_EXCEPTION(
       "Unbound buffers not supported yet for ibverbs transport");
 }
 
 // Receive into the specified buffer from the remote side of pair.
-void Pair::recv(transport::UnboundBuffer* tbuf, uint64_t slot) {
+void Pair::recv(transport::UnboundBuffer* tbuf, uint64_t slot, size_t offset, size_t nbytes) {
   GLOO_THROW_INVALID_OPERATION_EXCEPTION(
       "Unbound buffers not supported yet for ibverbs transport");
 }

--- a/gloo/transport/ibverbs/pair.h
+++ b/gloo/transport/ibverbs/pair.h
@@ -68,10 +68,10 @@ class Pair : public ::gloo::transport::Pair {
   createRecvBuffer(int slot, void* ptr, size_t size) override;
 
   // Send from the specified buffer to remote side of pair.
-  virtual void send(transport::UnboundBuffer* tbuf, uint64_t tag) override;
+  virtual void send(transport::UnboundBuffer* tbuf, uint64_t tag, size_t offset, size_t nbytes) override;
 
   // Receive into the specified buffer from the remote side of pair.
-  virtual void recv(transport::UnboundBuffer* tbuf, uint64_t tag) override;
+  virtual void recv(transport::UnboundBuffer* tbuf, uint64_t tag, size_t offset, size_t nbytes) override;
 
   void handleCompletionEvent();
 

--- a/gloo/transport/pair.h
+++ b/gloo/transport/pair.h
@@ -37,10 +37,18 @@ class Pair {
   createRecvBuffer(int slot, void* ptr, size_t size) = 0;
 
   // Send from the specified buffer to remote side of pair.
-  virtual void send(UnboundBuffer* buf, uint64_t tag) = 0;
+  virtual void send(
+      UnboundBuffer* buf,
+      uint64_t tag,
+      size_t offset = 0,
+      size_t nbytes = 0) = 0;
 
   // Receive into the specified buffer from the remote side of pair.
-  virtual void recv(UnboundBuffer* buf, uint64_t tag) = 0;
+  virtual void recv(
+      UnboundBuffer* buf,
+      uint64_t tag,
+      size_t offset = 0,
+      size_t nbytes = 0) = 0;
 };
 
 } // namespace transport

--- a/gloo/transport/tcp/context.h
+++ b/gloo/transport/tcp/context.h
@@ -47,7 +47,8 @@ class Context : public ::gloo::transport::Context,
 
   std::mutex m_;
 
-  using pendingRecvTuple = std::tuple<UnboundBuffer*, std::unordered_set<int>>;
+  using pendingRecvTuple =
+      std::tuple<UnboundBuffer*, size_t, size_t, std::unordered_set<int>>;
 
   // Buffers with pending receive operation by slot.
   std::unordered_map<uint64_t, std::deque<pendingRecvTuple>> pendingRecv_;
@@ -60,16 +61,22 @@ class Context : public ::gloo::transport::Context,
   void recvFromAny(
       UnboundBuffer* buf,
       uint64_t slot,
+      size_t offset,
+      size_t nbytes,
       std::vector<int> srcRanks);
 
   int recvFromAnyFindRank(
       UnboundBuffer* buf,
       uint64_t slot,
+      size_t offset,
+      size_t nbytes,
       std::vector<int> srcRanks);
 
   UnboundBuffer* recvFromAnyCallback(
       int rank,
-      uint64_t slot);
+      uint64_t slot,
+      size_t* offset,
+      size_t* nbytes);
 
   friend class Pair;
 

--- a/gloo/transport/tcp/pair.cc
+++ b/gloo/transport/tcp/pair.cc
@@ -54,7 +54,7 @@ Pair::Pair(
     const std::shared_ptr<Device>& dev,
     const int rank,
     std::chrono::milliseconds timeout,
-    std::function<tcp::UnboundBuffer*(uint64_t slot)> fn)
+    recvCallbackType fn)
     : dev_(dev),
       rank_(rank),
       state_(INITIALIZING),
@@ -272,40 +272,54 @@ void Pair::connect(const Address& peer) {
 }
 
 ssize_t Pair::writeBuildIov(Op& op, struct iovec* iov, int& ioc) {
-  ssize_t nbytes = 0;
+  ssize_t len = 0;
   ioc = 0;
 
   // Include preamble if necessary
   if (op.nwritten < sizeof(op.preamble)) {
     iov[ioc].iov_base = ((char*)&op.preamble) + op.nwritten;
     iov[ioc].iov_len = sizeof(op.preamble) - op.nwritten;
-    nbytes += iov[ioc].iov_len;
+    len += iov[ioc].iov_len;
     ioc++;
   }
 
   // Include remaining buffer segment if applicable
   char* ptr = nullptr;
   auto opcode = op.getOpcode();
+
+  // Send data to a remote buffer
   if (opcode == Op::SEND_BUFFER) {
-    ptr = (char*)op.buf->ptr_;
-  } else if (opcode == Op::SEND_UNBOUND_BUFFER) {
-    ptr = (char*)op.ubuf->ptr;
-  } else {
-    return nbytes;
+    char* ptr = (char*)op.buf->ptr_;
+    size_t offset = op.preamble.offset;
+    size_t nbytes = op.preamble.length;
+    if (op.nwritten > sizeof(op.preamble)) {
+      offset += op.nwritten - sizeof(op.preamble);
+      nbytes -= op.nwritten - sizeof(op.preamble);
+    }
+    iov[ioc].iov_base = ptr + offset;
+    iov[ioc].iov_len = nbytes;
+    len += iov[ioc].iov_len;
+    ioc++;
+    return len;
   }
 
-  size_t offset = op.preamble.offset;
-  size_t length = op.preamble.length;
-  if (op.nwritten > sizeof(op.preamble)) {
-    offset += op.nwritten - sizeof(op.preamble);
-    length -= op.nwritten - sizeof(op.preamble);
+  // Send data to a remote unbound buffer
+  if (opcode == Op::SEND_UNBOUND_BUFFER) {
+    char* ptr = (char*)op.ubuf->ptr;
+    size_t offset = op.offset;
+    size_t nbytes = op.nbytes;
+    if (op.nwritten > sizeof(op.preamble)) {
+      offset += op.nwritten - sizeof(op.preamble);
+      nbytes -= op.nwritten - sizeof(op.preamble);
+    }
+    iov[ioc].iov_base = ptr + offset;
+    iov[ioc].iov_len = nbytes;
+    len += iov[ioc].iov_len;
+    ioc++;
+    return len;
   }
-  iov[ioc].iov_base = ptr + offset;
-  iov[ioc].iov_len = length;
-  nbytes += iov[ioc].iov_len;
-  ioc++;
 
-  return nbytes;
+  return len;
 }
 
 // write is called from:
@@ -425,23 +439,23 @@ bool Pair::readBuildIov(Op& op, struct iovec& iov) {
   // Remote side is sending data to an unbound buffer; read payload
   if (opcode == Op::SEND_UNBOUND_BUFFER) {
     if (op.ubuf == nullptr) {
-      auto localRecv = localPendingRecv_.find(op.preamble.slot);
-      GLOO_ENFORCE(localRecv != localPendingRecv_.end());
-      auto& bufs = localRecv->second;
-      GLOO_ENFORCE(!bufs.empty());
-      op.ubuf = bufs.front();
-      bufs.pop_front();
+      auto it = localPendingRecv_.find(op.preamble.slot);
+      GLOO_ENFORCE(it != localPendingRecv_.end());
+      auto& tuples = it->second;
+      GLOO_ENFORCE(!tuples.empty());
+      std::tie(op.ubuf, op.offset, op.nbytes) = tuples.front();
+      tuples.pop_front();
     }
 
     auto offset = op.nread - sizeof(op.preamble);
-    iov.iov_base = ((char*) op.ubuf->ptr) + offset;
+    iov.iov_base = ((char*)op.ubuf->ptr) + op.offset + offset;
     iov.iov_len = op.preamble.length - offset;
 
     // There must always be a non-zero number of bytes to read
     GLOO_ENFORCE_GT(iov.iov_len, 0);
 
     // Bytes read must be in bounds for target buffer
-    GLOO_ENFORCE_LE(op.preamble.length, op.ubuf->size);
+    GLOO_ENFORCE_LE(op.preamble.length, op.nbytes);
     return true;
   }
 
@@ -576,11 +590,13 @@ void Pair::handleRemotePendingSend(const Op& op) {
   // the context whether or not there are any recv-from-any operations
   // that this send can fulfill.
   if (remotePendingSend_[slot] > 0) {
-    auto buf = recvFromAnyCallback_(slot);
+    size_t offset;
+    size_t nbytes;
+    auto buf = recvFromAnyCallback_(slot, &offset, &nbytes);
     if (buf != nullptr) {
-      localPendingRecv_[slot].push_back(buf);
+      localPendingRecv_[slot].push_back(std::make_tuple(buf, offset, nbytes));
       remotePendingSend_[slot]--;
-      sendNotifyRecvReady(buf, slot);
+      sendNotifyRecvReady(buf, slot, nbytes);
     }
   }
 }
@@ -601,10 +617,13 @@ void Pair::handleRemotePendingRecv(const Op& op) {
   if (it != localPendingSend_.end()) {
     auto& pendingSends = it->second;
     if (!pendingSends.empty()) {
-      auto buf = pendingSends.front();
+      UnboundBuffer* buf;
+      size_t offset;
+      size_t nbytes;
+      std::tie(buf, offset, nbytes) = pendingSends.front();
       pendingSends.pop_front();
       remotePendingRecv_[slot]--;
-      sendUnboundBuffer(buf, slot);
+      sendUnboundBuffer(buf, slot, offset, nbytes);
     }
   }
 }
@@ -941,39 +960,66 @@ Pair::createRecvBuffer(int slot, void* ptr, size_t size) {
 }
 
 // Send from the specified buffer to remote side of pair.
-void Pair::send(transport::UnboundBuffer* tbuf, uint64_t slot) {
+void Pair::send(
+    transport::UnboundBuffer* tbuf,
+    uint64_t slot,
+    size_t offset,
+    size_t nbytes) {
   auto buf = static_cast<tcp::UnboundBuffer*>(tbuf);
+
+  GLOO_ENFORCE_GE(offset, 0);
+  GLOO_ENFORCE_LT(offset, buf->size);
+  GLOO_ENFORCE_GT(nbytes, 0);
+  GLOO_ENFORCE_LE(nbytes, buf->size - offset);
 
   std::unique_lock<std::mutex> lock(m_);
   checkErrorState();
 
   // Execute this send if there is a remote pending receive.
   if (remotePendingRecv_[slot] > 0) {
-    sendUnboundBuffer(buf, slot);
+    sendUnboundBuffer(buf, slot, offset, nbytes);
     remotePendingRecv_[slot]--;
     return;
   }
 
   // Notify peer of this pending send.
-  localPendingSend_[slot].push_back(buf);
-  sendNotifySendReady(buf, slot);
+  localPendingSend_[slot].push_back(std::make_tuple(buf, offset, nbytes));
+  sendNotifySendReady(buf, slot, nbytes);
 }
 
 // Receive into the specified buffer from the remote side of pair.
-void Pair::recv(transport::UnboundBuffer* tbuf, uint64_t slot) {
+void Pair::recv(
+    transport::UnboundBuffer* tbuf,
+    uint64_t slot,
+    size_t offset,
+    size_t nbytes) {
   auto buf = static_cast<tcp::UnboundBuffer*>(tbuf);
+
+  GLOO_ENFORCE_GE(offset, 0);
+  GLOO_ENFORCE_LT(offset, buf->size);
+  GLOO_ENFORCE_GT(nbytes, 0);
+  GLOO_ENFORCE_LE(nbytes, buf->size - offset);
 
   std::unique_lock<std::mutex> lock(m_);
   checkErrorState();
 
   // Notify peer of this pending recv.
-  localPendingRecv_[slot].push_back(buf);
+  localPendingRecv_[slot].push_back(std::make_tuple(buf, offset, nbytes));
   remotePendingSend_[slot]--;
-  sendNotifyRecvReady(buf, slot);
+  sendNotifyRecvReady(buf, slot, nbytes);
 }
 
-bool Pair::tryRecv(transport::UnboundBuffer* tbuf, uint64_t slot) {
+bool Pair::tryRecv(
+    transport::UnboundBuffer* tbuf,
+    uint64_t slot,
+    size_t offset,
+    size_t nbytes) {
   auto buf = static_cast<tcp::UnboundBuffer*>(tbuf);
+
+  GLOO_ENFORCE_GE(offset, 0);
+  GLOO_ENFORCE_LT(offset, buf->size);
+  GLOO_ENFORCE_GT(nbytes, 0);
+  GLOO_ENFORCE_LE(nbytes, buf->size - offset);
 
   std::unique_lock<std::mutex> lock(m_);
   checkErrorState();
@@ -984,40 +1030,49 @@ bool Pair::tryRecv(transport::UnboundBuffer* tbuf, uint64_t slot) {
   }
 
   // Notify peer of this pending recv.
-  localPendingRecv_[slot].push_back(buf);
+  localPendingRecv_[slot].push_back(std::make_tuple(buf, offset, nbytes));
   remotePendingSend_[slot]--;
-  sendNotifyRecvReady(buf, slot);
+  sendNotifyRecvReady(buf, slot, nbytes);
   return true;
 }
 
-void Pair::sendUnboundBuffer(UnboundBuffer* buf, uint64_t slot) {
+void Pair::sendUnboundBuffer(
+    UnboundBuffer* buf,
+    uint64_t slot,
+    size_t offset,
+    size_t nbytes) {
   Op op;
-  op.preamble.nbytes = sizeof(op.preamble) + buf->size;
+  op.preamble.nbytes = sizeof(op.preamble) + nbytes;
   op.preamble.opcode = Op::SEND_UNBOUND_BUFFER;
   op.preamble.slot = slot;
-  op.preamble.offset = 0;
-  op.preamble.length = buf->size;
+  op.preamble.length = nbytes;
   op.ubuf = buf;
+  op.offset = offset;
+  op.nbytes = nbytes;
   sendAsyncMode(op);
 }
 
-void Pair::sendNotifyRecvReady(const UnboundBuffer* buf, uint64_t slot) {
+void Pair::sendNotifyRecvReady(
+    const UnboundBuffer* buf,
+    uint64_t slot,
+    size_t nbytes) {
   Op op;
   op.preamble.nbytes = sizeof(op.preamble);
   op.preamble.opcode = Op::NOTIFY_RECV_READY;
   op.preamble.slot = slot;
-  op.preamble.offset = 0;
-  op.preamble.length = buf->size;
+  op.preamble.length = nbytes;
   sendAsyncMode(op);
 }
 
-void Pair::sendNotifySendReady(const UnboundBuffer* buf, uint64_t slot) {
+void Pair::sendNotifySendReady(
+    const UnboundBuffer* buf,
+    uint64_t slot,
+    size_t nbytes) {
   Op op;
   op.preamble.nbytes = sizeof(op.preamble);
   op.preamble.opcode = Op::NOTIFY_SEND_READY;
   op.preamble.slot = slot;
-  op.preamble.offset = 0;
-  op.preamble.length = buf->size;
+  op.preamble.length = nbytes;
   sendAsyncMode(op);
 }
 

--- a/gloo/transport/tcp/pair.h
+++ b/gloo/transport/tcp/pair.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -68,6 +69,10 @@ struct Op {
   UnboundBuffer* ubuf;
   size_t nread;
   size_t nwritten;
+
+  // Byte offset to read from/write to and byte count.
+  size_t offset;
+  size_t nbytes;
 };
 
 class Pair : public ::gloo::transport::Pair {
@@ -79,12 +84,15 @@ class Pair : public ::gloo::transport::Pair {
     CLOSED = 5,
   };
 
+  using recvCallbackType = std::function<
+      tcp::UnboundBuffer*(uint64_t slot, size_t* offset, size_t* nbytes)>;
+
  public:
   explicit Pair(
       const std::shared_ptr<Device>& dev,
       const int rank,
       std::chrono::milliseconds timeout,
-      std::function<tcp::UnboundBuffer*(uint64_t slot)> fn);
+      recvCallbackType fn);
 
   virtual ~Pair();
 
@@ -98,22 +106,38 @@ class Pair : public ::gloo::transport::Pair {
 
   virtual void setSync(bool sync, bool busyPoll) override;
 
-  virtual std::unique_ptr<::gloo::transport::Buffer>
-  createSendBuffer(int slot, void* ptr, size_t size) override;
+  virtual std::unique_ptr<::gloo::transport::Buffer> createSendBuffer(
+      int slot,
+      void* ptr,
+      size_t size) override;
 
-  virtual std::unique_ptr<::gloo::transport::Buffer>
-  createRecvBuffer(int slot, void* ptr, size_t size) override;
+  virtual std::unique_ptr<::gloo::transport::Buffer> createRecvBuffer(
+      int slot,
+      void* ptr,
+      size_t size) override;
 
   // Send from the specified buffer to remote side of pair.
-  virtual void send(transport::UnboundBuffer* tbuf, uint64_t tag) override;
+  virtual void send(
+      transport::UnboundBuffer* tbuf,
+      uint64_t tag,
+      size_t offset,
+      size_t nbytes) override;
 
   // Receive into the specified buffer from the remote side of pair.
-  virtual void recv(transport::UnboundBuffer* tbuf, uint64_t tag) override;
+  virtual void recv(
+      transport::UnboundBuffer* tbuf,
+      uint64_t tag,
+      size_t offset,
+      size_t nbytes) override;
 
   // Attempt to receive into the specified buffer from the remote side
   // of pair. Returns true if there was a remote pending send and the
   // recv is in progress, false otherwise.
-  bool tryRecv(transport::UnboundBuffer* tbuf, uint64_t tag);
+  bool tryRecv(
+      transport::UnboundBuffer* tbuf,
+      uint64_t tag,
+      size_t offset,
+      size_t nbytes);
 
   void handleEvents(int events);
 
@@ -138,21 +162,34 @@ class Pair : public ::gloo::transport::Pair {
   std::condition_variable cv_;
   std::map<int, Buffer*> buffers_;
 
-  std::unordered_map<uint64_t, std::deque<tcp::UnboundBuffer*>> localPendingSend_;
-  std::unordered_map<uint64_t, std::deque<tcp::UnboundBuffer*>> localPendingRecv_;
+  // Tuple captures pointer to unbound buffer, byte offset, and byte count.
+  using UnboundBufferOp = std::tuple<tcp::UnboundBuffer*, size_t, size_t>;
+
+  std::unordered_map<uint64_t, std::deque<UnboundBufferOp>> localPendingSend_;
+  std::unordered_map<uint64_t, std::deque<UnboundBufferOp>> localPendingRecv_;
   std::unordered_map<uint64_t, int> remotePendingSend_;
   std::unordered_map<uint64_t, int> remotePendingRecv_;
 
-  void sendUnboundBuffer(tcp::UnboundBuffer* buf, uint64_t slot);
-  void sendNotifyRecvReady(const tcp::UnboundBuffer* buf, uint64_t slot);
-  void sendNotifySendReady(const tcp::UnboundBuffer* buf, uint64_t slot);
+  void sendUnboundBuffer(
+      tcp::UnboundBuffer* buf,
+      uint64_t slot,
+      size_t offset,
+      size_t nbytes);
+  void sendNotifyRecvReady(
+      const tcp::UnboundBuffer* buf,
+      uint64_t slot,
+      size_t nbytes);
+  void sendNotifySendReady(
+      const tcp::UnboundBuffer* buf,
+      uint64_t slot,
+      size_t nbytes);
 
   // Callback to issue when the remote side of the pair has
   // notified us that a send operation is ready to go. This is used to
   // implement recv-from-any on unbound buffers. The callback returns
   // an unbound buffer if there is a pending recv-from-any that
   // matches the rank of the remote side of this pair.
-  std::function<tcp::UnboundBuffer*(uint64_t slot)> recvFromAnyCallback_;
+  recvCallbackType recvFromAnyCallback_;
 
   void listen();
   void connect(const Address& peer);

--- a/gloo/transport/tcp/unbound_buffer.cc
+++ b/gloo/transport/tcp/unbound_buffer.cc
@@ -11,6 +11,7 @@
 
 #include <stdexcept>
 
+#include "gloo/common/logging.h"
 #include "gloo/transport/tcp/context.h"
 
 namespace gloo {
@@ -68,16 +69,40 @@ void UnboundBuffer::waitSend(int* rank) {
   }
 }
 
-void UnboundBuffer::send(int dstRank, uint64_t slot) {
-  context_->getPair(dstRank)->send(this, slot);
+void UnboundBuffer::send(
+    int dstRank,
+    uint64_t slot,
+    size_t offset,
+    size_t nbytes) {
+  if (nbytes == 0) {
+    GLOO_ENFORCE_LT(offset, this->size);
+    nbytes = this->size - offset;
+  }
+  context_->getPair(dstRank)->send(this, slot, offset, nbytes);
 }
 
-void UnboundBuffer::recv(int srcRank, uint64_t slot) {
-  context_->getPair(srcRank)->recv(this, slot);
+void UnboundBuffer::recv(
+    int srcRank,
+    uint64_t slot,
+    size_t offset,
+    size_t nbytes) {
+  if (nbytes == 0) {
+    GLOO_ENFORCE_LT(offset, this->size);
+    nbytes = this->size - offset;
+  }
+  context_->getPair(srcRank)->recv(this, slot, offset, nbytes);
 }
 
-void UnboundBuffer::recv(std::vector<int> srcRanks, uint64_t slot) {
-  context_->recvFromAny(this, slot, srcRanks);
+void UnboundBuffer::recv(
+    std::vector<int> srcRanks,
+    uint64_t slot,
+    size_t offset,
+    size_t nbytes) {
+  if (nbytes == 0) {
+    GLOO_ENFORCE_LT(offset, this->size);
+    nbytes = this->size - offset;
+  }
+  context_->recvFromAny(this, slot, offset, nbytes, srcRanks);
 }
 
 } // namespace tcp

--- a/gloo/transport/tcp/unbound_buffer.h
+++ b/gloo/transport/tcp/unbound_buffer.h
@@ -36,11 +36,17 @@ class UnboundBuffer : public ::gloo::transport::UnboundBuffer {
 
   void waitSend(int* rank) override;
 
-  void send(int dstRank, uint64_t slot) override;
+  void send(int dstRank, uint64_t slot, size_t offset, size_t nbytes = 0)
+      override;
 
-  void recv(int srcRank, uint64_t slot) override;
+  void recv(int srcRank, uint64_t slot, size_t offset, size_t nbytes = 0)
+      override;
 
-  void recv(std::vector<int> srcRanks, uint64_t slot) override;
+  void recv(
+      std::vector<int> srcRanks,
+      uint64_t slot,
+      size_t offset,
+      size_t nbytes) override;
 
  protected:
   void handleRecvCompletion(int rank);

--- a/gloo/transport/unbound_buffer.h
+++ b/gloo/transport/unbound_buffer.h
@@ -41,11 +41,23 @@ class UnboundBuffer {
   // If specified, the destination of this send is stored in the rank pointer.
   virtual void waitSend(int* rank = nullptr) = 0;
 
-  virtual void send(int dstRank, uint64_t slot) = 0;
+  virtual void send(
+      int dstRank,
+      uint64_t slot,
+      size_t offset = 0,
+      size_t nbytes = 0) = 0;
 
-  virtual void recv(int srcRank, uint64_t slot) = 0;
+  virtual void recv(
+      int srcRank,
+      uint64_t slot,
+      size_t offset = 0,
+      size_t nbytes = 0) = 0;
 
-  virtual void recv(std::vector<int> srcRanks, uint64_t slot) = 0;
+  virtual void recv(
+      std::vector<int> srcRanks,
+      uint64_t slot,
+      size_t offset = 0,
+      size_t nbytes = 0) = 0;
 };
 
 } // namespace transport


### PR DESCRIPTION
This allows for reusing an unbound buffer for multiple send or
recv operations against non-empty ranges. This is useful when receiving
into the same target buffer from multiple peers, or when doing
double-buffering against a single region.

For example, you can now issue N consecutive recv operations against the
same unbound buffer and get notified as they complete in sequence, as
opposed to only getting notified when a single recv operation for the
entire buffer completes.