### PR TITLE
Use type instead of memoryType when building with CUDA 10

### DIFF
--- a/gloo/cuda.h
+++ b/gloo/cuda.h
@@ -122,7 +122,11 @@ class BuilderHelpers {
       return std::all_of(inputs.begin(), inputs.end(), [](const T* ptr) {
         cudaPointerAttributes attr;
         auto rv = cudaPointerGetAttributes(&attr, ptr);
-        return rv == cudaSuccess && attr.memoryType == cudaMemoryTypeDevice;
+        #ifdef CUDA_VERSION >= 10000
+          return rv == cudaSuccess && attr.type == cudaMemoryTypeDevice;
+        #else
+          return rv == cudaSuccess && attr.memoryType == cudaMemoryTypeDevice;
+        #endif
       });
     }
 };

--- a/gloo/cuda.h
+++ b/gloo/cuda.h
@@ -122,7 +122,7 @@ class BuilderHelpers {
       return std::all_of(inputs.begin(), inputs.end(), [](const T* ptr) {
         cudaPointerAttributes attr;
         auto rv = cudaPointerGetAttributes(&attr, ptr);
-        #ifdef CUDA_VERSION >= 10000
+        #if CUDA_VERSION >= 10000
           return rv == cudaSuccess && attr.type == cudaMemoryTypeDevice;
         #else
           return rv == cudaSuccess && attr.memoryType == cudaMemoryTypeDevice;


### PR DESCRIPTION
CUDA 10 builds of PyTorch are giving lots of __CUDA_DEPRECATED warnings with usage of `memoryType`. This PR should resolve those warnings in PyTorch builds.