### PR TITLE
Don't mark CMakeLists.txt files every time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,6 @@ if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
   message(FATAL_ERROR "Gloo can only be built on 64-bit systems.")
 endif()
 
-# We want CMake to glob everything every time.
-execute_process(COMMAND
-  find "${PROJECT_SOURCE_DIR}" -name "CMakeLists.txt" -exec touch {} \;)
-
 # Local CMake modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 


### PR DESCRIPTION
This is messing up incremental builds in pytorch/pytorch#12829.

This was originally meant to ensure newly added files were picked up
automatically. We can expect folks to rerun CMake when adding files.

cc @ezyang