### PR TITLE
Make tcp/pair.cc exception handling more robust

### DIFF
--- a/gloo/test/CMakeLists.txt
+++ b/gloo/test/CMakeLists.txt
@@ -8,12 +8,14 @@ set(GLOO_TEST_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/gather_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/linux_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/main.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/multiproc_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/reduce_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/send_recv_test.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/transport_test.cc"
   )
 
 add_executable(gloo_test ${GLOO_TEST_SRCS})
-target_link_libraries(gloo_test gloo gloo_builder gtest)
+target_link_libraries(gloo_test gloo gloo_builder gtest rt)
 
 if(USE_CUDA)
   set(GLOO_TEST_CUDA_SRCS

--- a/gloo/test/multiproc_test.h
+++ b/gloo/test/multiproc_test.h
@@ -25,6 +25,7 @@ namespace gloo {
 namespace test {
 
 const int kExitWithIoException = 10;
+const auto kMultiProcTimeout = std::chrono::milliseconds(200);
 
 class MultiProcTest : public ::testing::Test {
  protected:
@@ -77,7 +78,7 @@ class MultiProcWorker {
       std::function<void(std::shared_ptr<Context>)> fn) {
     auto context =
       std::make_shared<::gloo::rendezvous::Context>(rank, size);
-    context->setTimeout(std::chrono::milliseconds(300));
+    context->setTimeout(std::chrono::milliseconds(kMultiProcTimeout));
     context->connectFullMesh(*store_, device_);
     sem_post(semaphore_);
     fn(std::move(context));

--- a/gloo/test/transport_test.cc
+++ b/gloo/test/transport_test.cc
@@ -86,9 +86,14 @@ TEST_P(TransportMultiProcTest, IoErrors) {
     std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
   }
 
-  // Kill one of the processes and wait for all to exit
+  // Kill one of the processes and wait for all to exit.
+  // Expect this to take less time than the default timeout.
+  const auto start = std::chrono::high_resolution_clock::now();
   signalProcess(0, SIGKILL);
   wait();
+  const auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::high_resolution_clock::now() - start);
+  ASSERT_LT(delta.count(), kMultiProcTimeout.count() / 2);
 
   for (auto i = 0; i < processCount; i++) {
     if (i != 0) {

--- a/gloo/transport/tcp/buffer.h
+++ b/gloo/transport/tcp/buffer.h
@@ -40,9 +40,6 @@ class Buffer : public ::gloo::transport::Buffer {
   void handleRecvCompletion();
   void handleSendCompletion();
 
-  void signalError(const std::exception_ptr& ex);
-  void checkErrorState();
-
   Pair* pair_;
 
   std::mutex m_;
@@ -54,6 +51,12 @@ class Buffer : public ::gloo::transport::Buffer {
   std::atomic<int> sendPending_;
 
   std::exception_ptr ex_;
+
+  // Throws if an exception if set.
+  void throwIfException();
+
+  // Set exception and wake up any waitRecv/waitSend threads.
+  void signalException(std::exception_ptr);
 
   friend class Pair;
 };

--- a/gloo/transport/tcp/pair.h
+++ b/gloo/transport/tcp/pair.h
@@ -209,7 +209,7 @@ class Pair : public ::gloo::transport::Pair {
     return timeout_;
   }
 
-  void signalIoFailureExternal(const std::string& msg);
+  std::exception_ptr signalExceptionExternal(const std::string& msg);
 
   friend class Buffer;
 
@@ -244,9 +244,18 @@ class Pair : public ::gloo::transport::Pair {
   void waitUntilConnected(std::unique_lock<std::mutex>& lock, bool useTimeout);
   void verifyConnected();
 
-  // Used to signal IO exceptions from one thread and propagate onto others.
-  void signalIoFailure(const std::string& msg);
-  void checkErrorState();
+  // Throws if an exception if set.
+  void throwIfException();
+
+  // Set exception and signal all pending buffers.
+  // This moves the pair to the CLOSED state which means that the
+  // handleEvents function is no longer called by the device loop.
+  void signalException(const std::string& msg);
+  void signalException(std::exception_ptr);
+
+  // Like signalException, but throws exception as well.
+  void signalAndThrowException(const std::string& msg);
+  void signalAndThrowException(std::exception_ptr ex);
 };
 
 } // namespace tcp


### PR DESCRIPTION
This changes the following things:

* signalIoFailure is now called signalException.
* signalException no longer throws; it signals the exception to all known buffers, stores the exception, and closes the connection.
* signalAndThrowException behaves exactly as signalException, but throws the exception.
* The read and write functions no longer throw, but return false on failure.
* No more big try/catch block in the handleEvents function that swallows all ::gloo::IoException instances (this function is called from the pair's event loop and must never throw).
* The connection is ALWAYS closed when an exception is set (either from within pair.cc or through a application side timeout in buffer.cc).
* Add test to check that the time between killing a process and the other processes terminating is less than the default timeout.