### PR TITLE
Use single object to keep track of pending ops

### DIFF
--- a/gloo/test/CMakeLists.txt
+++ b/gloo/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(GLOO_TEST_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/gather_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/linux_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/main.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/memory_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/multiproc_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/reduce_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/send_recv_test.cc"

--- a/gloo/test/memory_test.cc
+++ b/gloo/test/memory_test.cc
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2019-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "gloo/test/base_test.h"
+
+#include <fstream>
+#include <sstream>
+
+namespace gloo {
+namespace test {
+namespace {
+
+size_t readResidentSetSize() {
+  std::stringstream path;
+  path << "/proc/" << getpid() << "/statm";
+  std::ifstream f(path.str());
+  size_t size;
+  size_t resident;
+  f >> size >> resident;
+  return (getpagesize() * resident);
+}
+
+class MemoryTest : public BaseTest {};
+
+TEST_F(MemoryTest, ManySlotsNoLeaks) {
+  spawn(2, [&](std::shared_ptr<Context> context) {
+    size_t tmp0;
+    size_t tmp1;
+    auto buf0 = context->createUnboundBuffer(&tmp0, sizeof(tmp0));
+    auto buf1 = context->createUnboundBuffer(&tmp1, sizeof(tmp1));
+    auto step = [&](size_t slot) {
+      const auto peer = 1 - context->rank;
+      if (context->rank == 0) {
+        buf0->send(peer, slot);
+        buf1->recv(peer, slot);
+        buf0->waitSend();
+        buf1->waitRecv();
+      } else {
+        buf0->recv(peer, slot);
+        buf1->send(peer, slot);
+        buf0->waitRecv();
+        buf1->waitSend();
+      }
+    };
+
+    // Prime processes with a few send/recv ping/pongs
+    size_t slot = 0;
+    for (auto i = 0; i < 10; i++) {
+      step(slot++);
+    }
+
+    // Read current memory usage and run for a while
+    auto baselineResidentSetSize = readResidentSetSize();
+    for (auto i = 0; i < 10000; i++) {
+      step(slot++);
+    }
+
+    // Ensure memory usage didn't increase
+    auto newResidentSetSize = readResidentSetSize();
+    ASSERT_EQ(baselineResidentSetSize, newResidentSetSize);
+  });
+}
+
+} // namespace
+} // namespace test
+} // namespace gloo

--- a/gloo/transport/tcp/context.h
+++ b/gloo/transport/tcp/context.h
@@ -21,10 +21,134 @@ namespace gloo {
 namespace transport {
 namespace tcp {
 
+// PendingOpTally keeps track of the number of remote pending
+// operations (both pending send and receive operations) for a single
+// slot, across all pairs. This used to be tracked in the pairs
+// themselves, but to support receive-from-any we need a centralized
+// view into all pending send operations. This class facilitaties that
+// centralized view for both pending send and receive operations.
+//
+// The tally for a slot is accessed through the transport context
+// object defined further down in this file.
+//
+class PendingOpTally {
+ public:
+  using tally_count_t = int8_t;
+
+ private:
+  // Counts either pending send or pending recv operations.
+  // Keeps track of number of non-zero entries such that
+  // we can remove tallies that are no longer needed.
+  class Tally {
+   public:
+    explicit Tally(size_t length) : tally(length), nz(0) {}
+
+    tally_count_t get(size_t rank) {
+      return tally[rank];
+    }
+
+    tally_count_t update(size_t rank, tally_count_t v) {
+      auto cur = tally[rank];
+      if (cur == 0) {
+        cur += v;
+        if (cur != 0) {
+          nz++;
+        }
+      } else {
+        cur += v;
+        if (cur == 0) {
+          nz--;
+        }
+      }
+      tally[rank] = cur;
+      return cur;
+    }
+
+    std::vector<int8_t> tally;
+    ssize_t nz;
+  };
+
+ public:
+  explicit PendingOpTally(size_t length) : send_(length), recv_(length) {}
+
+  bool empty() {
+    return send_.nz == 0 && recv_.nz == 0;
+  }
+
+  tally_count_t getSend(size_t rank) {
+    return send_.get(rank);
+  }
+
+  tally_count_t getRecv(size_t rank) {
+    return recv_.get(rank);
+  }
+
+  tally_count_t updateSend(size_t rank, tally_count_t v) {
+    return send_.update(rank, v);
+  }
+
+  tally_count_t updateRecv(size_t rank, tally_count_t v) {
+    return recv_.update(rank, v);
+  }
+
+ protected:
+  Tally send_;
+  Tally recv_;
+};
+
 // Forward declaration
+class Context;
 class Device;
 class Pair;
 class UnboundBuffer;
+
+// Short lived object that is returned to Pair functions. It has a
+// lock on the context object so that it can atomically retrieve and
+// mutate the pending operation tally as well as check for pending
+// send or receive operations.
+//
+// It is expected to be destructed as soon as it leaves scope.
+//
+class ContextMutator {
+  using tally_count_t = PendingOpTally::tally_count_t;
+  using PendingOpTallyMap = std::unordered_map<uint64_t, PendingOpTally>;
+  using PendingOpTallyIterator = PendingOpTallyMap::iterator;
+
+ public:
+  ContextMutator(Context& context, uint64_t slot, uint64_t rank);
+
+  ~ContextMutator();
+
+  // Current number of remote pending recv operations for rank.
+  tally_count_t getRemotePendingRecv();
+
+  // Current number of remote pending send operations for rank.
+  tally_count_t getRemotePendingSend();
+
+  // Update number of remote pending recv operations by `v`.
+  tally_count_t updateRemotePendingRecv(tally_count_t v);
+
+  // Update number of remote pending send operations by `v`.
+  tally_count_t updateRemotePendingSend(tally_count_t v);
+
+  // Find buffer for which we should execute a recv operation.
+  UnboundBuffer* findRecvFromAny(size_t* offset, size_t* nbytes);
+
+ protected:
+  std::unique_lock<std::mutex> lock_;
+  Context& context_;
+  const uint64_t slot_;
+  const uint64_t rank_;
+
+  // Every operation that requires the ContextMutator will access the
+  // pending operation tally. Therefore we can perform lookup of this
+  // object at construction time.
+  PendingOpTallyIterator it_;
+
+  // If the existing iterator does not exists, insert new pending
+  // operation tally object and return the new iterator.
+  PendingOpTallyIterator insertIfNotExists();
+};
 
 class Context : public ::gloo::transport::Context,
                 public std::enable_shared_from_this<Context> {
@@ -50,8 +174,8 @@ class Context : public ::gloo::transport::Context,
   // Buffers with pending receive operation by slot.
   std::unordered_map<uint64_t, std::deque<pendingRecvTuple>> pendingRecv_;
 
-  // Per slot, map of rank to the number of pending send operations.
-  std::unordered_map<uint64_t, std::unordered_map<int, int>> pendingRemoteSend_;
+  // Pending remote operation tally by slot number.
+  std::unordered_map<uint64_t, PendingOpTally> remotePendingOp_;
 
   // This function registers the specified unbound buffer for a receive
   // operation from any of the specified ranks.
@@ -69,9 +193,9 @@ class Context : public ::gloo::transport::Context,
       size_t nbytes,
       std::vector<int> srcRanks);
 
-  UnboundBuffer* recvFromAnyCallback(
-      int rank,
+  UnboundBuffer* findRecvFromAny(
       uint64_t slot,
+      int rank,
       size_t* offset,
       size_t* nbytes);
 
@@ -79,6 +203,8 @@ class Context : public ::gloo::transport::Context,
   // waiting for a send or recv operation on an unbound buffer times
   // out. All pairs should be signaled and closed in that event.
   void signalException(const std::string& msg);
+
+  friend class ContextMutator;
 
   friend class UnboundBuffer;
 };


### PR DESCRIPTION
This used to be tracked in the pair instances, but to support
receive-from-any we need a centralized view into all pending send
operations. This class facilitaties that centralized view for both
pending send and receive operations.

Before this change, instances of the gloo::transport::tcp::Pair class
kept track of remote pending send and recv operations, and notified the
transport context of remote pending send operations. Functionality wise
this was fine, but it didn't include cleanup of unused slots, nor did it
allow for adding this easily. By centralizing the pending operation
tally in a single object, there is only a single object to clean up when
the pending operation tally drops to 0.

This resulted in a memory leak proportional to the number of used slots,
as reported in pytorch/pytorch#16144. Confirmed that the repro listed in
that issue no longer shows an increase in memory. Also added a test in
gloo/test/memory_test.cc that performs the same test.