### PR TITLE
Ensure pairs are destructed before their device

### DIFF
--- a/gloo/transport/tcp/context.cc
+++ b/gloo/transport/tcp/context.cc
@@ -73,9 +73,14 @@ bool ContextMutator::findRecvFromAny(
 }
 
 Context::Context(std::shared_ptr<Device> device, int rank, int size)
-    : ::gloo::transport::Context(rank, size), device_(device) {}
+    : ::gloo::transport::Context(rank, size), device_(std::move(device)) {}
 
-Context::~Context() {}
+Context::~Context() {
+  // Pairs refer to device by raw pointer.
+  // Ensure they are destructed before the device.
+  pairs_.clear();
+  device_.reset();
+}
 
 std::unique_ptr<transport::Pair>& Context::createPair(int rank) {
   pairs_[rank] = std::unique_ptr<transport::Pair>(


### PR DESCRIPTION
As of 27760a38 the pairs refer to their underlying device with a raw
pointer, which introduced a possible destruction order problem.

If the device is only referred to by the transport context, it would be
destructed before the pairs would be destructed, per ordering of members
in `gloo::transport::Context` and `gloo::transport::tcp::Context`. Then
upon destruction of the pairs, they were no longer able to unregister
their file descriptor from the device, because it was already
destructed.