### PR TITLE
Add header files for std::array into source code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
     - os: linux
       compiler: gcc
       env: BUILD_CUDA=ON
+    - os: linux
+      compiler: clang
+      env: BUILD_CUDA=OFF
 
 cache:
   apt: true

--- a/gloo/allgather.cc
+++ b/gloo/allgather.cc
@@ -8,6 +8,7 @@
 
 #include "gloo/allgather.h"
 
+#include <array>
 #include <cstring>
 
 #include "gloo/common/logging.h"

--- a/gloo/allreduce.cc
+++ b/gloo/allreduce.cc
@@ -8,6 +8,7 @@
 
 #include "gloo/allreduce.h"
 
+#include <array>
 #include <algorithm>
 #include <cstring>
 

--- a/gloo/reduce.cc
+++ b/gloo/reduce.cc
@@ -8,6 +8,7 @@
 
 #include "gloo/reduce.h"
 
+#include <array>
 #include <algorithm>
 #include <cstring>
 

--- a/gloo/test/multiproc_test.cc
+++ b/gloo/test/multiproc_test.cc
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 #include <ftw.h>
 
+#include <array>
 #include <string>
 #include <sstream>
 #include <vector>

--- a/gloo/test/send_recv_test.cc
+++ b/gloo/test/send_recv_test.cc
@@ -9,6 +9,7 @@
 #include "gloo/test/base_test.h"
 
 #include <unordered_set>
+#include <array>
 
 #include "gloo/transport/tcp/unbound_buffer.h"
 

--- a/gloo/transport/tcp/pair.cc
+++ b/gloo/transport/tcp/pair.cc
@@ -8,6 +8,7 @@
 
 #include "gloo/transport/tcp/pair.h"
 
+#include <array>
 #include <algorithm>
 #include <sstream>
 


### PR DESCRIPTION
We use this library with clang and libc++. But, it does not compile with libc++.

![image](https://user-images.githubusercontent.com/1345314/54101170-75007400-4405-11e9-96be-1f55cc0377f9.png)

When it compiles, this error occurred. Then, we send this PR for fix to add include files for std::array

We also add that includes for benchmark and google test
  - e.g. `cmake . -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON`