### PR TITLE
Fix to adding include std::array in cuda file

### DIFF
--- a/gloo/cuda_allreduce_ring_chunked.h
+++ b/gloo/cuda_allreduce_ring_chunked.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "gloo/algorithm.h"
 #include "gloo/cuda.h"
 #include "gloo/cuda_workspace.h"


### PR DESCRIPTION
I use this library with clang, libc++, cuda. But, it can't compile with libc++.

![스크린샷 2019-04-26 오후 4 33 19](https://user-images.githubusercontent.com/9068279/56793261-8e8b3d00-6846-11e9-9026-529e34f08d1f.png)

I think It's the same problem as https://github.com/facebookincubator/gloo/pull/172.
So I also fixed to add include files for std::array in cuda file.

I tested in clang 6, cuda 10.0.

