### PR TITLE
Add allgatherv

### DIFF
--- a/gloo/CMakeLists.txt
+++ b/gloo/CMakeLists.txt
@@ -8,6 +8,7 @@ set(GLOO_HDRS)
 list(APPEND GLOO_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/algorithm.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/allgather.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/allgatherv.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_local.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/barrier.cc"
@@ -23,6 +24,7 @@ list(APPEND GLOO_HDRS
   "${CMAKE_CURRENT_SOURCE_DIR}/algorithm.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allgather.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allgather_ring.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/allgatherv.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_bcube.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_halving_doubling.h"

--- a/gloo/allgatherv.cc
+++ b/gloo/allgatherv.cc
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2019-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "gloo/allgatherv.h"
+
+#include <cstring>
+#include <numeric>
+
+#include "gloo/common/logging.h"
+#include "gloo/types.h"
+
+namespace gloo {
+
+void AllgathervOptions::setElementSize(size_t elementSize) {
+  if (this->elementSize == 0) {
+    this->elementSize = elementSize;
+  } else {
+    GLOO_ENFORCE_EQ(
+        elementSize,
+        this->elementSize,
+        "Element size does not match existing value. ",
+        "Please double check that the input and output types match.");
+  }
+}
+
+void AllgathervOptions::setInput(
+    std::unique_ptr<transport::UnboundBuffer> buf,
+    size_t elementSize) {
+  setElementSize(elementSize);
+  this->in = std::move(buf);
+}
+
+void AllgathervOptions::setInput(
+    void* ptr,
+    size_t elements,
+    size_t elementSize) {
+  setElementSize(elementSize);
+  this->in = context->createUnboundBuffer(ptr, elements * elementSize);
+}
+
+void AllgathervOptions::setOutput(
+    std::unique_ptr<transport::UnboundBuffer> buf,
+    std::vector<size_t> elements,
+    size_t elementSize) {
+  const auto totalElements =
+      std::accumulate(elements.begin(), elements.end(), size_t(0));
+  setElementSize(elementSize);
+  GLOO_ENFORCE_EQ(elements.size(), context->size);
+  this->elements = std::move(elements);
+  GLOO_ENFORCE_EQ(totalElements * elementSize, buf->size);
+  this->out = std::move(buf);
+}
+
+void AllgathervOptions::setOutput(
+    void* ptr,
+    std::vector<size_t> elements,
+    size_t elementSize) {
+  const auto totalElements =
+      std::accumulate(elements.begin(), elements.end(), size_t(0));
+  setElementSize(elementSize);
+  GLOO_ENFORCE_EQ(elements.size(), context->size);
+  this->elements = std::move(elements);
+  this->out = context->createUnboundBuffer(ptr, totalElements * elementSize);
+}
+
+void allgatherv(AllgathervOptions& opts) {
+  const auto& context = opts.context;
+  transport::UnboundBuffer* in = opts.in.get();
+  transport::UnboundBuffer* out = opts.out.get();
+  const auto slot = Slot::build(kAllgatherSlotPrefix, opts.tag);
+
+  // Sanity checks
+  GLOO_ENFORCE(opts.elementSize > 0);
+  const auto recvRank = (context->size + context->rank - 1) % context->size;
+  GLOO_ENFORCE(
+      context->getPair(recvRank),
+      "missing connection between rank " + std::to_string(context->rank) +
+          " (this process) and rank " + std::to_string(recvRank));
+  const auto sendRank = (context->size + context->rank + 1) % context->size;
+  GLOO_ENFORCE(
+      context->getPair(sendRank),
+      "missing connection between rank " + std::to_string(context->rank) +
+          " (this process) and rank " + std::to_string(sendRank));
+
+  // Compute byte counts and offsets into output buffer.
+  std::vector<size_t> byteCounts;
+  std::vector<size_t> byteOffsets;
+  byteCounts.reserve(context->size);
+  byteOffsets.reserve(context->size);
+  size_t offset = 0;
+  for (const auto& elements : opts.elements) {
+    const auto bytes = elements * opts.elementSize;
+    byteCounts.push_back(bytes);
+    byteOffsets.push_back(offset);
+    offset += bytes;
+  }
+
+  // If the input buffer is specified, the output buffer needs to be primed.
+  if (in != nullptr) {
+    GLOO_ENFORCE_EQ(byteCounts[context->rank], in->size);
+    memcpy(
+        static_cast<uint8_t*>(out->ptr) + byteOffsets[context->rank],
+        static_cast<uint8_t*>(in->ptr),
+        in->size);
+  }
+
+  const auto baseIndex = context->size + context->rank;
+  for (auto i = 0; i < context->size - 1; i++) {
+    const size_t sendIndex = (baseIndex - i) % context->size;
+    const size_t recvIndex = (baseIndex - i - 1) % context->size;
+
+    if (i == 0) {
+      out->send(sendRank, slot, byteOffsets[sendIndex], byteCounts[sendIndex]);
+      out->recv(recvRank, slot, byteOffsets[recvIndex], byteCounts[recvIndex]);
+      continue;
+    }
+
+    // Wait for previous operations to complete before kicking off new ones.
+    out->waitSend(opts.timeout);
+    out->waitRecv(opts.timeout);
+    out->send(sendRank, slot, byteOffsets[sendIndex], byteCounts[sendIndex]);
+    out->recv(recvRank, slot, byteOffsets[recvIndex], byteCounts[recvIndex]);
+  }
+
+  // Wait for final operations to complete.
+  out->waitSend(opts.timeout);
+  out->waitRecv(opts.timeout);
+}
+
+} // namespace gloo

--- a/gloo/allgatherv.h
+++ b/gloo/allgatherv.h
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2019-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "gloo/context.h"
+#include "gloo/transport/unbound_buffer.h"
+
+namespace gloo {
+
+class AllgathervOptions {
+ public:
+  explicit AllgathervOptions(const std::shared_ptr<Context>& context)
+      : context(context), timeout(context->getTimeout()) {}
+
+  template <typename T>
+  void setInput(std::unique_ptr<transport::UnboundBuffer> buf) {
+    setInput(std::move(buf), sizeof(T));
+  }
+
+  template <typename T>
+  void setInput(T* ptr, size_t elements) {
+    setInput(static_cast<void*>(ptr), elements, sizeof(T));
+  }
+
+  template <typename T>
+  void setOutput(
+      std::unique_ptr<transport::UnboundBuffer> buf,
+      std::vector<size_t> elements) {
+    setOutput(std::move(buf), std::move(elements), sizeof(T));
+  }
+
+  template <typename T>
+  void setOutput(T* ptr, std::vector<size_t> elements) {
+    setOutput(static_cast<void*>(ptr), std::move(elements), sizeof(T));
+  }
+
+  void setTag(uint32_t tag) {
+    this->tag = tag;
+  }
+
+  void setTimeout(std::chrono::milliseconds timeout) {
+    this->timeout = timeout;
+  }
+
+ protected:
+  std::shared_ptr<Context> context;
+  std::unique_ptr<transport::UnboundBuffer> in;
+  std::unique_ptr<transport::UnboundBuffer> out;
+
+  // Number of elements per rank in the output.
+  std::vector<size_t> elements;
+
+  // Number of bytes per element.
+  size_t elementSize = 0;
+
+  // Tag for this operation.
+  // Must be unique across operations executing in parallel.
+  uint32_t tag = 0;
+
+  // End-to-end timeout for this operation.
+  std::chrono::milliseconds timeout;
+
+  // Set element size, or check the argument is equal to the current value.
+  void setElementSize(size_t elementSize);
+
+  // Untemplated implementation of setInput on unbound buffer.
+  void setInput(
+      std::unique_ptr<transport::UnboundBuffer> buf,
+      size_t elementSize);
+
+  // Untemplated implementation of setInput on opaque pointer.
+  void setInput(void* ptr, size_t elements, size_t elementSize);
+
+  // Untemplated implementation of setOutput on unbound buffer.
+  void setOutput(
+      std::unique_ptr<transport::UnboundBuffer> buf,
+      std::vector<size_t> elements,
+      size_t elementSize);
+
+  // Untemplated implementation of setOutput on opaque pointer.
+  void setOutput(void* ptr, std::vector<size_t> elements, size_t elementSize);
+
+  friend void allgatherv(AllgathervOptions&);
+};
+
+void allgatherv(AllgathervOptions& opts);
+
+} // namespace gloo

--- a/gloo/test/CMakeLists.txt
+++ b/gloo/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(GLOO_TEST_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/allgather_test.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/allgatherv_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/allreduce_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/barrier_test.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/broadcast_test.cc"

--- a/gloo/test/allgatherv_test.cc
+++ b/gloo/test/allgatherv_test.cc
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2019-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <functional>
+#include <thread>
+#include <vector>
+
+#include "gloo/allgatherv.h"
+#include "gloo/common/common.h"
+#include "gloo/test/base_test.h"
+
+namespace gloo {
+namespace test {
+namespace {
+
+using Param = std::tuple<int, int, bool>;
+
+class AllgathervTest : public BaseTest,
+                       public ::testing::WithParamInterface<Param> {};
+
+TEST_P(AllgathervTest, Default) {
+  auto contextSize = std::get<0>(GetParam());
+  auto dataSize = std::get<1>(GetParam());
+  auto passBuffers = std::get<2>(GetParam());
+
+  spawn(contextSize, [&](std::shared_ptr<Context> context) {
+    // This test uses the same output size for every iteration,
+    // but assigns different counts to different ranks.
+    std::vector<uint64_t> output(
+        dataSize * (context->size * (context->size - 1)) / 2);
+    std::vector<uint64_t> input(dataSize * context->size);
+    std::vector<size_t> counts(context->size);
+
+    // Use each rank as a base once.
+    for (auto i = 0; i < context->size; i++) {
+      // Initialize counts per rank.
+      for (auto j = 0; j < context->size; j++) {
+        counts[(i + j) % context->size] = j * dataSize;
+      }
+
+      // Count for this process's rank.
+      const auto count =
+          ((context->size - i + context->rank) % context->size) * dataSize;
+
+      // Run with raw pointers and sizes in options.
+      AllgathervOptions opts(context);
+      std::fill(input.begin(), input.end(), context->rank);
+      if (passBuffers) {
+        opts.setInput<uint64_t>(context->createUnboundBuffer(
+            input.data(), count * sizeof(uint64_t)));
+      } else {
+        opts.setInput(input.data(), count);
+      }
+      std::fill(output.begin(), output.end(), UINT64_MAX);
+      if (passBuffers) {
+        opts.setOutput<uint64_t>(
+            context->createUnboundBuffer(
+                output.data(), output.size() * sizeof(uint64_t)),
+            counts);
+      } else {
+        opts.setOutput(output.data(), counts);
+      }
+      allgatherv(opts);
+
+      // Verify output.
+      size_t offset = 0;
+      for (auto j = 0; j < context->size; j++) {
+        for (auto k = 0; k < counts[j]; k++) {
+          ASSERT_EQ(j, output[offset + k])
+              << "Mismatch at offset=" << offset << ", k=" << k;
+        }
+        offset += counts[j];
+      }
+    }
+  });
+}
+
+INSTANTIATE_TEST_CASE_P(
+    AllgathervDefault,
+    AllgathervTest,
+    ::testing::Combine(
+        ::testing::Values(2, 4, 7),
+        ::testing::Values(1, 10, 100, 1000),
+        ::testing::Values(false, true)));
+
+TEST_F(AllgathervTest, TestTimeout) {
+  spawn(2, [&](std::shared_ptr<Context> context) {
+    Fixture<uint64_t> output(context, 1, context->size);
+    std::vector<size_t> counts({1, 1});
+    AllgathervOptions opts(context);
+    opts.setOutput(output.getPointer(), counts);
+    opts.setTimeout(std::chrono::milliseconds(10));
+    if (context->rank == 0) {
+      try {
+        allgatherv(opts);
+        FAIL() << "Expected exception to be thrown";
+      } catch (::gloo::IoException& e) {
+        ASSERT_NE(std::string(e.what()).find("Timed out"), std::string::npos);
+      }
+    }
+  });
+}
+
+} // namespace
+} // namespace test
+} // namespace gloo

--- a/gloo/transport/tcp/unbound_buffer.cc
+++ b/gloo/transport/tcp/unbound_buffer.cc
@@ -131,7 +131,7 @@ void UnboundBuffer::send(
     uint64_t slot,
     size_t offset,
     size_t nbytes) {
-  if (nbytes == 0) {
+  if (nbytes == UINT64_MAX) {
     GLOO_ENFORCE_LE(offset, this->size);
     nbytes = this->size - offset;
   }
@@ -143,7 +143,7 @@ void UnboundBuffer::recv(
     uint64_t slot,
     size_t offset,
     size_t nbytes) {
-  if (nbytes == 0) {
+  if (nbytes == UINT64_MAX) {
     GLOO_ENFORCE_LE(offset, this->size);
     nbytes = this->size - offset;
   }
@@ -155,7 +155,7 @@ void UnboundBuffer::recv(
     uint64_t slot,
     size_t offset,
     size_t nbytes) {
-  if (nbytes == 0) {
+  if (nbytes == UINT64_MAX) {
     GLOO_ENFORCE_LT(offset, this->size);
     nbytes = this->size - offset;
   }

--- a/gloo/transport/unbound_buffer.h
+++ b/gloo/transport/unbound_buffer.h
@@ -90,19 +90,19 @@ class UnboundBuffer {
       int dstRank,
       uint64_t slot,
       size_t offset = 0,
-      size_t nbytes = 0) = 0;
+      size_t nbytes = UINT64_MAX) = 0;
 
   virtual void recv(
       int srcRank,
       uint64_t slot,
       size_t offset = 0,
-      size_t nbytes = 0) = 0;
+      size_t nbytes = UINT64_MAX) = 0;
 
   virtual void recv(
       std::vector<int> srcRanks,
       uint64_t slot,
       size_t offset = 0,
-      size_t nbytes = 0) = 0;
+      size_t nbytes = UINT64_MAX) = 0;
 };
 
 } // namespace transport


### PR DESCRIPTION
Summary:
This addition includes a tweak to the unbound buffer default
arguments. For allgatherv, it is valid for a process to contribute
nothing, and `nbytes == 0` was special cased. Use a default value of
UINT64_MAX to make `nbytes == 0` a valid call.

Differential Revision: D15174130

