### PR TITLE
Add ReduceOp.XOR to torch.distributed

### DIFF
--- a/gloo/math.h
+++ b/gloo/math.h
@@ -73,6 +73,16 @@ void min(T* a, const T* b, size_t n) {
 }
 
 template <typename T>
+void XOR(void* c_, const void* a_, const void* b_, size_t n) {
+  T* c = static_cast<T*>(c_);
+  const T* a = static_cast<const T*>(a_);
+  const T* b = static_cast<const T*>(b_);
+  for (auto i = 0; i < n; i++) {
+    c[i] = a[i] ^ b[i];
+  }
+}
+
+template <typename T>
 T roundUp(T value, T multiple) {
   T remainder = value % multiple;
   if (remainder == 0) {


### PR DESCRIPTION
Summary: Add ReduceOp.XOR to torch.distributed for use with torch.LongTensor allreduce functions and modify unit-tests accordingly

Differential Revision: D15223418

