### PR TITLE
Hipify gloo

### DIFF
--- a/gloo/cuda.cu
+++ b/gloo/cuda.cu
@@ -59,8 +59,8 @@ CudaStream::CudaStream(int deviceId, cudaStream_t stream)
 CudaStream::CudaStream(CudaStream&& other) noexcept
     : deviceId_(other.deviceId_),
       stream_(other.stream_),
-      streamOwner_(other.streamOwner_),
-      event_(other.event_) {
+      event_(other.event_),
+      streamOwner_(other.streamOwner_) {
   other.deviceId_ = kInvalidDeviceId;
   other.stream_ = nullptr;
   other.event_ = nullptr;

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -35,6 +35,14 @@ parser.add_argument(
     action='store_true',
     help="Only print the list of hipify files.")
 
+parser.add_argument(
+    '--root-dir',
+    type=str,
+    default="gloo",
+    help="The root directory of gloo project",
+    required=False)
+
+
 args = parser.parse_args()
 
 amd_build_dir = os.path.dirname(os.path.realpath(__file__))
@@ -48,7 +56,7 @@ if args.output_directory:
     out_dir = args.output_directory
 
 includes = [
-    "gloo/*cuda*",
+    os.path.join(args.root_dir, "*cuda*"),
 ]
 
 ignores = [


### PR DESCRIPTION
Summary: hipify gloo. Also change the target's naming convention from gloo-cuda to gloo_gpu_cuda.

Differential Revision: D16130418

