### PR TITLE
Make collectives work with single process context

### DIFF
--- a/gloo/test/allgather_test.cc
+++ b/gloo/test/allgather_test.cc
@@ -162,7 +162,7 @@ INSTANTIATE_TEST_CASE_P(
     AllgatherNewDefault,
     AllgatherNewTest,
     ::testing::Combine(
-        ::testing::Values(2, 4, 7),
+        ::testing::Values(1, 2, 4, 7),
         ::testing::ValuesIn(genMemorySizes()),
         ::testing::Values(false, true)));
 

--- a/gloo/test/allgatherv_test.cc
+++ b/gloo/test/allgatherv_test.cc
@@ -84,7 +84,7 @@ INSTANTIATE_TEST_CASE_P(
     AllgathervDefault,
     AllgathervTest,
     ::testing::Combine(
-        ::testing::Values(2, 4, 7),
+        ::testing::Values(1, 2, 4, 7),
         ::testing::Values(1, 10, 100, 1000),
         ::testing::Values(false, true)));
 

--- a/gloo/test/barrier_test.cc
+++ b/gloo/test/barrier_test.cc
@@ -116,7 +116,7 @@ TEST_P(BarrierNewTest, Default) {
 INSTANTIATE_TEST_CASE_P(
     BarrierNewDefault,
     BarrierNewTest,
-    ::testing::Values(2, 4, 7));
+    ::testing::Values(1, 2, 4, 7));
 
 TEST_F(BarrierNewTest, TestTimeout) {
   spawn(2, [&](std::shared_ptr<Context> context) {

--- a/gloo/test/broadcast_test.cc
+++ b/gloo/test/broadcast_test.cc
@@ -185,7 +185,7 @@ INSTANTIATE_TEST_CASE_P(
     BroadcastNewDefault,
     BroadcastNewTest,
     ::testing::Combine(
-        ::testing::Values(2, 4, 7),
+        ::testing::Values(1, 2, 4, 7),
         ::testing::Values(1, 10, 100),
         ::testing::Values(false, true),
         ::testing::Values(false, true)));

--- a/gloo/test/gather_test.cc
+++ b/gloo/test/gather_test.cc
@@ -73,7 +73,7 @@ INSTANTIATE_TEST_CASE_P(
     GatherDefault,
     GatherTest,
     ::testing::Combine(
-        ::testing::Values(2, 4, 7),
+        ::testing::Values(1, 2, 4, 7),
         ::testing::ValuesIn(genMemorySizes())));
 
 TEST_F(GatherTest, TestTimeout) {

--- a/gloo/test/reduce_test.cc
+++ b/gloo/test/reduce_test.cc
@@ -92,7 +92,7 @@ INSTANTIATE_TEST_CASE_P(
     ReduceDefault,
     ReduceTest,
     ::testing::Combine(
-        ::testing::Values(2, 4, 7),
+        ::testing::Values(1, 2, 4, 7),
         ::testing::ValuesIn(genMemorySizes()),
         ::testing::Values(true, false)));
 

--- a/gloo/test/scatter_test.cc
+++ b/gloo/test/scatter_test.cc
@@ -67,7 +67,7 @@ INSTANTIATE_TEST_CASE_P(
     ScatterDefault,
     ScatterTest,
     ::testing::Combine(
-        ::testing::Values(2, 4, 7),
+        ::testing::Values(1, 2, 4, 7),
         ::testing::ValuesIn(genMemorySizes())));
 
 TEST_F(ScatterTest, TestTimeout) {


### PR DESCRIPTION
Summary:
This is a base case where these collectives are usually a nop. For
code simplicity it is better to not have to differentiate between N=1
and N>1 cases. It's easy to support this case here, so we should. This
commit adds the N=1 case to the test cases and fixes the collective
implementations to deal with it where needed.

Differential Revision: D16205644

