### PR TITLE
Make aligned_allocator use posix_memalign

### DIFF
--- a/gloo/benchmark/benchmark.h
+++ b/gloo/benchmark/benchmark.h
@@ -16,6 +16,7 @@
 #include "gloo/algorithm.h"
 #include "gloo/benchmark/options.h"
 #include "gloo/context.h"
+#include "gloo/common/aligned_allocator.h"
 #include "gloo/common/common.h"
 
 namespace gloo {

--- a/gloo/benchmark/main.cc
+++ b/gloo/benchmark/main.cc
@@ -19,6 +19,7 @@
 #include "gloo/broadcast_one_to_all.h"
 #include "gloo/pairwise_exchange.h"
 #include "gloo/reduce_scatter.h"
+#include "gloo/common/aligned_allocator.h"
 #include "gloo/common/common.h"
 #include "gloo/common/logging.h"
 #include "gloo/context.h"

--- a/gloo/common/CMakeLists.txt
+++ b/gloo/common/CMakeLists.txt
@@ -4,6 +4,7 @@ set(GLOO_COMMON_SRCS
   )
 
 set(GLOO_COMMON_HDRS
+  "${CMAKE_CURRENT_SOURCE_DIR}/aligned_allocator.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/common.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/error.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/linux.h"

--- a/gloo/common/aligned_allocator.h
+++ b/gloo/common/aligned_allocator.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <memory>
+
+namespace gloo {
+
+// Align buffers to 32 bytes to support vectorized code
+const size_t kBufferAlignment = 32;
+
+template <typename T, int ALIGNMENT = kBufferAlignment>
+class aligned_allocator {
+  static_assert(
+      !(ALIGNMENT & (ALIGNMENT - 1)),
+      "alignment must be a power of 2");
+
+ public:
+  using value_type = T;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+
+  template <typename U>
+  struct rebind {
+    using other = aligned_allocator<U, ALIGNMENT>;
+  };
+
+  inline explicit aligned_allocator() = default;
+  inline ~aligned_allocator() = default;
+  inline explicit aligned_allocator(const aligned_allocator& a) = default;
+
+  inline pointer address(reference r) {
+    return &r;
+  }
+
+  inline const_pointer address(const_reference r) {
+    return &r;
+  }
+
+  inline pointer allocate(
+      size_type sz,
+      typename std::allocator<void>::const_pointer = 0) {
+    pointer p;
+    if (posix_memalign(
+            reinterpret_cast<void**>(&p), ALIGNMENT, sizeof(T) * sz)) {
+      abort();
+    }
+    return p;
+  }
+
+  void deallocate(pointer p, size_type /*sz*/) {
+    free(p);
+  }
+};
+
+} // namespace gloo

--- a/gloo/common/common.h
+++ b/gloo/common/common.h
@@ -8,53 +8,9 @@
 
 #pragma once
 
-#include <cstdlib>
-#include <malloc.h>
 #include <memory>
 
 namespace gloo {
-
-// Align buffers to 32 bytes to support vectorized code
-const size_t kBufferAlignment = 32;
-
-template <typename T, int ALIGNMENT = kBufferAlignment>
-class aligned_allocator {
- public:
-  using value_type = T;
-  using pointer = value_type*;
-  using const_pointer = const value_type*;
-  using reference = value_type&;
-  using const_reference = const value_type&;
-  using size_type = std::size_t;
-  using difference_type = std::ptrdiff_t;
-
-  template <typename U>
-  struct rebind {
-    using other = aligned_allocator<U, ALIGNMENT>;
-  };
-
-  inline explicit aligned_allocator() = default;
-  inline ~aligned_allocator() = default;
-  inline explicit aligned_allocator(const aligned_allocator& a) = default;
-
-  inline pointer address(reference r) {
-    return &r;
-  }
-  inline const_pointer address(const_reference r) {
-    return &r;
-  }
-
-  inline pointer allocate(
-      size_type sz,
-      typename std::allocator<void>::const_pointer = 0) {
-    auto x = memalign(ALIGNMENT, sizeof(T) * sz);
-    return reinterpret_cast<pointer>(x);
-  }
-
-  void deallocate(pointer p, size_type /*sz*/) {
-    free(p);
-  }
-};
 
 // make_unique is a C++14 feature. If we don't have 14, we will emulate
 // its behavior. This is copied from folly/Memory.h

--- a/gloo/test/allreduce_test.cc
+++ b/gloo/test/allreduce_test.cc
@@ -17,6 +17,7 @@
 #include "gloo/allreduce_halving_doubling.h"
 #include "gloo/allreduce_ring.h"
 #include "gloo/allreduce_ring_chunked.h"
+#include "gloo/common/aligned_allocator.h"
 #include "gloo/test/base_test.h"
 
 namespace gloo {

--- a/gloo/test/reduce_scatter_test.cc
+++ b/gloo/test/reduce_scatter_test.cc
@@ -10,6 +10,7 @@
 #include <thread>
 #include <vector>
 
+#include "gloo/common/aligned_allocator.h"
 #include "gloo/reduce_scatter.h"
 #include "gloo/test/base_test.h"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #206 Remove superfluous asserts
* #204 Fix C++14 extension warning when compiling for C++11
* #200 Use constexpr value for unspecified nbytes argument
* #199 Make compilation of Linux source files conditional
* #198 Export macro for every transport that gets compiled
* **#197 Make aligned_allocator use posix_memalign**

This change makes the aligned allocator use posix_memalign over
memalign, which is a Linux specific call. This change also moves the
aligned allocator to a separate file per the realization that it is
used only in benchmark and test code.

Differential Revision: [D16801637](https://our.internmc.facebook.com/intern/diff/D16801637)