### PR TITLE
Use constexpr value for unspecified nbytes argument

### DIFF
--- a/gloo/transport/tcp/unbound_buffer.cc
+++ b/gloo/transport/tcp/unbound_buffer.cc
@@ -131,7 +131,9 @@ void UnboundBuffer::send(
     uint64_t slot,
     size_t offset,
     size_t nbytes) {
-  if (nbytes == UINT64_MAX) {
+  // Default the number of bytes to be equal to the number
+  // of bytes remaining in the buffer w.r.t. the offset.
+  if (nbytes == kUnspecifiedByteCount) {
     GLOO_ENFORCE_LE(offset, this->size);
     nbytes = this->size - offset;
   }
@@ -143,7 +145,9 @@ void UnboundBuffer::recv(
     uint64_t slot,
     size_t offset,
     size_t nbytes) {
-  if (nbytes == UINT64_MAX) {
+  // Default the number of bytes to be equal to the number
+  // of bytes remaining in the buffer w.r.t. the offset.
+  if (nbytes == kUnspecifiedByteCount) {
     GLOO_ENFORCE_LE(offset, this->size);
     nbytes = this->size - offset;
   }
@@ -155,7 +159,9 @@ void UnboundBuffer::recv(
     uint64_t slot,
     size_t offset,
     size_t nbytes) {
-  if (nbytes == UINT64_MAX) {
+  // Default the number of bytes to be equal to the number
+  // of bytes remaining in the buffer w.r.t. the offset.
+  if (nbytes == kUnspecifiedByteCount) {
     GLOO_ENFORCE_LT(offset, this->size);
     nbytes = this->size - offset;
   }

--- a/gloo/transport/tcp/unbound_buffer.h
+++ b/gloo/transport/tcp/unbound_buffer.h
@@ -38,10 +38,10 @@ class UnboundBuffer : public ::gloo::transport::UnboundBuffer {
   // If specified, the destination of this send is stored in the rank pointer.
   void waitSend(int* rank, std::chrono::milliseconds timeout) override;
 
-  void send(int dstRank, uint64_t slot, size_t offset, size_t nbytes = 0)
+  void send(int dstRank, uint64_t slot, size_t offset, size_t nbytes)
       override;
 
-  void recv(int srcRank, uint64_t slot, size_t offset, size_t nbytes = 0)
+  void recv(int srcRank, uint64_t slot, size_t offset, size_t nbytes)
       override;
 
   void recv(

--- a/gloo/transport/tcp/unbound_buffer.h
+++ b/gloo/transport/tcp/unbound_buffer.h
@@ -38,10 +38,10 @@ class UnboundBuffer : public ::gloo::transport::UnboundBuffer {
   // If specified, the destination of this send is stored in the rank pointer.
   void waitSend(int* rank, std::chrono::milliseconds timeout) override;
 
-  void send(int dstRank, uint64_t slot, size_t offset, size_t nbytes = 0)
+  void send(int dstRank, uint64_t slot, size_t offset, size_t count)
       override;
 
-  void recv(int srcRank, uint64_t slot, size_t offset, size_t nbytes = 0)
+  void recv(int srcRank, uint64_t slot, size_t offset, size_t count)
       override;
 
   void recv(

--- a/gloo/transport/tcp/unbound_buffer.h
+++ b/gloo/transport/tcp/unbound_buffer.h
@@ -38,10 +38,10 @@ class UnboundBuffer : public ::gloo::transport::UnboundBuffer {
   // If specified, the destination of this send is stored in the rank pointer.
   void waitSend(int* rank, std::chrono::milliseconds timeout) override;
 
-  void send(int dstRank, uint64_t slot, size_t offset, size_t count)
+  void send(int dstRank, uint64_t slot, size_t offset, size_t nbytes = 0)
       override;
 
-  void recv(int srcRank, uint64_t slot, size_t offset, size_t count)
+  void recv(int srcRank, uint64_t slot, size_t offset, size_t nbytes = 0)
       override;
 
   void recv(

--- a/gloo/transport/unbound_buffer.h
+++ b/gloo/transport/unbound_buffer.h
@@ -90,7 +90,7 @@ class UnboundBuffer {
   // If the byte count argument is not specified, it will default the
   // number of bytes to be equal to the number of bytes remaining in
   // the buffer w.r.t. the offset.
-  constexpr auto kUnspecifiedByteCount = std::numeric_limits<size_t>::max();
+  static constexpr auto kUnspecifiedByteCount = std::numeric_limits<size_t>::max();
 
   virtual void send(
       int dstRank,

--- a/gloo/transport/unbound_buffer.h
+++ b/gloo/transport/unbound_buffer.h
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 namespace gloo {
@@ -86,23 +87,28 @@ class UnboundBuffer {
         deadline - clock::now()));
   }
 
+  // If the byte count argument is not specified, it will default the
+  // number of bytes to be equal to the number of bytes remaining in
+  // the buffer w.r.t. the offset.
+  constexpr auto kUnspecifiedByteCount = std::numeric_limits<size_t>::max();
+
   virtual void send(
       int dstRank,
       uint64_t slot,
       size_t offset = 0,
-      size_t nbytes = UINT64_MAX) = 0;
+      size_t nbytes = kUnspecifiedByteCount) = 0;
 
   virtual void recv(
       int srcRank,
       uint64_t slot,
       size_t offset = 0,
-      size_t nbytes = UINT64_MAX) = 0;
+      size_t nbytes = kUnspecifiedByteCount) = 0;
 
   virtual void recv(
       std::vector<int> srcRanks,
       uint64_t slot,
       size_t offset = 0,
-      size_t nbytes = UINT64_MAX) = 0;
+      size_t nbytes = kUnspecifiedByteCount) = 0;
 };
 
 } // namespace transport


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #206 Remove superfluous asserts
* #204 Fix C++14 extension warning when compiling for C++11
* **#200 Use constexpr value for unspecified nbytes argument**
* #199 Make compilation of Linux source files conditional
* #198 Export macro for every transport that gets compiled
* #197 Make aligned_allocator use posix_memalign

Differential Revision: [D16801685](https://our.internmc.facebook.com/intern/diff/D16801685)