### PR TITLE
Fix instructions for installing benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Then build the benchmark, run:
 mkdir build
 cd build
 cmake ../ -DBUILD_BENCHMARK=1
+make
 ls -l gloo/benchmark/benchmark
 ```
 


### PR DESCRIPTION
The `make` command was missing to actually create the benchmark test.