### PR TITLE
Fix C++14 extension warning when compiling for C++11

### DIFF
--- a/gloo/benchmark/runner.cc
+++ b/gloo/benchmark/runner.cc
@@ -249,7 +249,8 @@ void Runner::run(BenchmarkFn<T>& fn, size_t n) {
     // Create warmup jobs for every thread
     std::vector<std::unique_ptr<RunnerJob>> jobs;
     for (auto i = 0; i < options_.threads; i++) {
-      auto fn = [&benchmark = benchmarks[i]] { benchmark->run(); };
+      auto& benchmark = benchmarks[i];
+      auto fn = [&benchmark] { benchmark->run(); };
       auto job = make_unique<RunnerJob>(fn, options_.warmupIterationCount);
       jobs.push_back(std::move(job));
     }
@@ -277,7 +278,8 @@ void Runner::run(BenchmarkFn<T>& fn, size_t n) {
   // Create jobs for every thread
   std::vector<std::unique_ptr<RunnerJob>> jobs;
   for (auto i = 0; i < options_.threads; i++) {
-    auto fn = [&benchmark = benchmarks[i]] { benchmark->run(); };
+    auto& benchmark = benchmarks[i];
+    auto fn = [&benchmark] { benchmark->run(); };
     auto job = make_unique<RunnerJob>(fn, iterations);
     jobs.push_back(std::move(job));
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #206 Remove superfluous asserts
* **#204 Fix C++14 extension warning when compiling for C++11**
* #200 Use constexpr value for unspecified nbytes argument
* #199 Make compilation of Linux source files conditional
* #198 Export macro for every transport that gets compiled
* #197 Make aligned_allocator use posix_memalign

Differential Revision: [D16801684](https://our.internmc.facebook.com/intern/diff/D16801684)