### PR TITLE
Remove superfluous asserts

### DIFF
--- a/gloo/transport/tcp/pair.cc
+++ b/gloo/transport/tcp/pair.cc
@@ -1012,8 +1012,6 @@ void Pair::send(
     size_t nbytes) {
   auto buf = static_cast<tcp::UnboundBuffer*>(tbuf)->getWeakNonOwningPtr();
 
-  GLOO_ENFORCE_GE(offset, 0);
-  GLOO_ENFORCE_GE(nbytes, 0);
   if (nbytes > 0) {
     GLOO_ENFORCE_LE(offset, tbuf->size);
     GLOO_ENFORCE_LE(nbytes, tbuf->size - offset);
@@ -1048,8 +1046,6 @@ void Pair::recv(
     size_t nbytes) {
   auto buf = static_cast<tcp::UnboundBuffer*>(tbuf)->getWeakNonOwningPtr();
 
-  GLOO_ENFORCE_GE(offset, 0);
-  GLOO_ENFORCE_GE(nbytes, 0);
   if (nbytes > 0) {
     GLOO_ENFORCE_LE(offset, tbuf->size);
     GLOO_ENFORCE_LE(nbytes, tbuf->size - offset);
@@ -1076,10 +1072,10 @@ bool Pair::tryRecv(
     size_t nbytes) {
   auto buf = static_cast<tcp::UnboundBuffer*>(tbuf)->getWeakNonOwningPtr();
 
-  GLOO_ENFORCE_GE(offset, 0);
-  GLOO_ENFORCE_LT(offset, tbuf->size);
-  GLOO_ENFORCE_GT(nbytes, 0);
-  GLOO_ENFORCE_LE(nbytes, tbuf->size - offset);
+  if (nbytes > 0) {
+    GLOO_ENFORCE_LE(offset, tbuf->size);
+    GLOO_ENFORCE_LE(nbytes, tbuf->size - offset);
+  }
 
   std::unique_lock<std::mutex> lock(m_);
   throwIfException();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#206 Remove superfluous asserts**
* #204 Fix C++14 extension warning when compiling for C++11
* #200 Use constexpr value for unspecified nbytes argument
* #199 Make compilation of Linux source files conditional
* #198 Export macro for every transport that gets compiled
* #197 Make aligned_allocator use posix_memalign

Usage of send/recv (including recv-from-any) with nbytes==0 is
allowed. The asserts for a direct send/recv for the offset and nbytes
argument checked that they are >= 0, which is always true since they
are unsigned integers.

The assert for a recv-from-any did NOT yet allow for an empty message.
This commit adds a test for that case and updates its asserts as well.

Differential Revision: [D16801687](https://our.internmc.facebook.com/intern/diff/D16801687)