### PR TITLE
Refactor algorithm tests to take transport parameter

### DIFF
--- a/gloo/test/allgatherv_test.cc
+++ b/gloo/test/allgatherv_test.cc
@@ -18,17 +18,18 @@ namespace gloo {
 namespace test {
 namespace {
 
-using Param = std::tuple<int, int, bool>;
+using Param = std::tuple<Transport, int, int, bool>;
 
 class AllgathervTest : public BaseTest,
                        public ::testing::WithParamInterface<Param> {};
 
 TEST_P(AllgathervTest, Default) {
-  auto contextSize = std::get<0>(GetParam());
-  auto dataSize = std::get<1>(GetParam());
-  auto passBuffers = std::get<2>(GetParam());
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  const auto dataSize = std::get<2>(GetParam());
+  const auto passBuffers = std::get<3>(GetParam());
 
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
     // This test uses the same output size for every iteration,
     // but assigns different counts to different ranks.
     std::vector<uint64_t> output(
@@ -84,12 +85,13 @@ INSTANTIATE_TEST_CASE_P(
     AllgathervDefault,
     AllgathervTest,
     ::testing::Combine(
+        ::testing::ValuesIn(kTransportsForFunctionAlgorithms),
         ::testing::Values(1, 2, 4, 7),
         ::testing::Values(1, 10, 100, 1000),
         ::testing::Values(false, true)));
 
 TEST_F(AllgathervTest, TestTimeout) {
-  spawn(2, [&](std::shared_ptr<Context> context) {
+  spawn(Transport::TCP, 2, [&](std::shared_ptr<Context> context) {
     Fixture<uint64_t> output(context, 1, context->size);
     std::vector<size_t> counts({1, 1});
     AllgathervOptions opts(context);

--- a/gloo/test/allreduce_test.cc
+++ b/gloo/test/allreduce_test.cc
@@ -42,99 +42,91 @@ using Func16 = void(
     int dataSize);
 
 // Test parameterization.
-using Param = std::tuple<int, int, std::function<Func>, int>;
-using ParamHP = std::tuple<int, int, std::function<Func16>>;
+using Param = std::tuple<Transport, int, int, std::function<Func>, int>;
+using ParamHP = std::tuple<Transport, int, int, std::function<Func16>>;
 
 template <typename Algorithm>
-class AllreduceConstructorTest : public BaseTest {
-};
+class AllreduceConstructorTest : public BaseTest {};
 
-typedef ::testing::Types<
-  AllreduceRing<float>,
-  AllreduceRingChunked<float> > AllreduceTypes;
+typedef ::testing::Types<AllreduceRing<float>, AllreduceRingChunked<float>>
+    AllreduceTypes;
 TYPED_TEST_CASE(AllreduceConstructorTest, AllreduceTypes);
 
 TYPED_TEST(AllreduceConstructorTest, InlinePointers) {
-  this->spawn(2, [&](std::shared_ptr<Context> context) {
-      float f = 1.0f;
-      TypeParam algorithm(
-        context,
-        {&f},
-        1);
-    });
+  this->spawn(Transport::TCP, 2, [&](std::shared_ptr<Context> context) {
+    float f = 1.0f;
+    TypeParam algorithm(context, {&f}, 1);
+  });
 }
 
 TYPED_TEST(AllreduceConstructorTest, SpecifyReductionFunction) {
-  this->spawn(2, [&](std::shared_ptr<Context> context) {
-      float f = 1.0f;
-      std::vector<float*> ptrs = {&f};
-      TypeParam algorithm(
-        context,
-        ptrs,
-        ptrs.size(),
-        ReductionFunction<float>::product);
-    });
+  this->spawn(Transport::TCP, 2, [&](std::shared_ptr<Context> context) {
+    float f = 1.0f;
+    std::vector<float*> ptrs = {&f};
+    TypeParam algorithm(
+        context, ptrs, ptrs.size(), ReductionFunction<float>::product);
+  });
 }
 
-static std::function<Func> allreduceRing = [](
-    std::shared_ptr<::gloo::Context> context,
-    std::vector<float*> dataPtrs,
-    int dataSize) {
-  ::gloo::AllreduceRing<float> algorithm(context, dataPtrs, dataSize);
-  algorithm.run();
-};
+static std::function<Func> allreduceRing =
+    [](std::shared_ptr<::gloo::Context> context,
+       std::vector<float*> dataPtrs,
+       int dataSize) {
+      ::gloo::AllreduceRing<float> algorithm(context, dataPtrs, dataSize);
+      algorithm.run();
+    };
 
-static std::function<Func16> allreduceRingHP = [](
-    std::shared_ptr<::gloo::Context> context,
-    std::vector<float16*> dataPtrs,
-    int dataSize) {
-  ::gloo::AllreduceRing<float16> algorithm(context, dataPtrs, dataSize);
-  algorithm.run();
-};
+static std::function<Func16> allreduceRingHP =
+    [](std::shared_ptr<::gloo::Context> context,
+       std::vector<float16*> dataPtrs,
+       int dataSize) {
+      ::gloo::AllreduceRing<float16> algorithm(context, dataPtrs, dataSize);
+      algorithm.run();
+    };
 
-static std::function<Func> allreduceRingChunked = [](
-    std::shared_ptr<::gloo::Context> context,
-    std::vector<float*> dataPtrs,
-    int dataSize) {
-  ::gloo::AllreduceRingChunked<float> algorithm(
-      context, dataPtrs, dataSize);
-  algorithm.run();
-};
+static std::function<Func> allreduceRingChunked =
+    [](std::shared_ptr<::gloo::Context> context,
+       std::vector<float*> dataPtrs,
+       int dataSize) {
+      ::gloo::AllreduceRingChunked<float> algorithm(
+          context, dataPtrs, dataSize);
+      algorithm.run();
+    };
 
-static std::function<Func16> allreduceRingChunkedHP = [](
-    std::shared_ptr<::gloo::Context> context,
-    std::vector<float16*> dataPtrs,
-    int dataSize) {
-  ::gloo::AllreduceRingChunked<float16> algorithm(
-      context, dataPtrs, dataSize);
-  algorithm.run();
-};
+static std::function<Func16> allreduceRingChunkedHP =
+    [](std::shared_ptr<::gloo::Context> context,
+       std::vector<float16*> dataPtrs,
+       int dataSize) {
+      ::gloo::AllreduceRingChunked<float16> algorithm(
+          context, dataPtrs, dataSize);
+      algorithm.run();
+    };
 
-static std::function<Func> allreduceHalvingDoubling = [](
-    std::shared_ptr<::gloo::Context> context,
-    std::vector<float*> dataPtrs,
-    int dataSize) {
-  ::gloo::AllreduceHalvingDoubling<float> algorithm(
-      context, dataPtrs, dataSize);
-  algorithm.run();
-};
+static std::function<Func> allreduceHalvingDoubling =
+    [](std::shared_ptr<::gloo::Context> context,
+       std::vector<float*> dataPtrs,
+       int dataSize) {
+      ::gloo::AllreduceHalvingDoubling<float> algorithm(
+          context, dataPtrs, dataSize);
+      algorithm.run();
+    };
 
-static std::function<Func> allreduceBcube = [](
-    std::shared_ptr<::gloo::Context> context,
-    std::vector<float*> dataPtrs,
-    int dataSize) {
-  ::gloo::AllreduceBcube<float> algorithm(context, dataPtrs, dataSize);
-  algorithm.run();
-};
+static std::function<Func> allreduceBcube =
+    [](std::shared_ptr<::gloo::Context> context,
+       std::vector<float*> dataPtrs,
+       int dataSize) {
+      ::gloo::AllreduceBcube<float> algorithm(context, dataPtrs, dataSize);
+      algorithm.run();
+    };
 
-static std::function<Func16> allreduceHalvingDoublingHP = [](
-    std::shared_ptr<::gloo::Context> context,
-    std::vector<float16*> dataPtrs,
-    int dataSize) {
-  ::gloo::AllreduceHalvingDoubling<float16> algorithm(
-      context, dataPtrs, dataSize);
-  algorithm.run();
-};
+static std::function<Func16> allreduceHalvingDoublingHP =
+    [](std::shared_ptr<::gloo::Context> context,
+       std::vector<float16*> dataPtrs,
+       int dataSize) {
+      ::gloo::AllreduceHalvingDoubling<float16> algorithm(
+          context, dataPtrs, dataSize);
+      algorithm.run();
+    };
 
 // Test fixture.
 class AllreduceTest : public BaseTest,
@@ -144,37 +136,45 @@ class AllreduceTestHP : public BaseTest,
                         public ::testing::WithParamInterface<ParamHP> {};
 
 TEST_P(AllreduceTest, SinglePointer) {
-  auto contextSize = std::get<0>(GetParam());
-  auto dataSize = std::get<1>(GetParam());
-  auto fn = std::get<2>(GetParam());
-  auto base = std::get<3>(GetParam());
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  const auto dataSize = std::get<2>(GetParam());
+  const auto fn = std::get<3>(GetParam());
+  const auto base = std::get<4>(GetParam());
 
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
-    const auto contextRank = context->rank;
-    auto buffer = newBuffer<float>(dataSize);
-    auto* ptr = buffer.data();
-    for (int i = 0; i < dataSize; i++) {
-      ptr[i] = contextRank;
-    }
+  spawn(
+      transport,
+      contextSize,
+      [&](std::shared_ptr<Context> context) {
+        const auto contextRank = context->rank;
+        auto buffer = newBuffer<float>(dataSize);
+        auto* ptr = buffer.data();
+        for (int i = 0; i < dataSize; i++) {
+          ptr[i] = contextRank;
+        }
 
-    fn(context, std::vector<float*>{ptr}, dataSize);
+        fn(context, std::vector<float*>{ptr}, dataSize);
 
-    auto expected = (contextSize * (contextSize - 1)) / 2;
-    for (int i = 0; i < dataSize; i++) {
-      ASSERT_EQ(expected, ptr[i]) << "Mismatch at index " << i;
-    }
-  }, base);
+        auto expected = (contextSize * (contextSize - 1)) / 2;
+        for (int i = 0; i < dataSize; i++) {
+          ASSERT_EQ(expected, ptr[i]) << "Mismatch at index " << i;
+        }
+      },
+      base);
 }
 
 TEST_F(AllreduceTest, MultipleAlgorithms) {
-  auto contextSize = 4;
-  auto dataSize = 1000;
-  auto fns = {allreduceRing,
-              allreduceRingChunked,
-              allreduceHalvingDoubling,
-              allreduceBcube};
+  const auto transport = Transport::TCP;
+  const auto contextSize = 4;
+  const auto dataSize = 1000;
+  const auto fns = {
+      allreduceRing,
+      allreduceRingChunked,
+      allreduceHalvingDoubling,
+      allreduceBcube,
+  };
 
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
     const auto contextRank = context->rank;
     auto buffer = newBuffer<float>(dataSize);
     auto* ptr = buffer.data();
@@ -205,12 +205,16 @@ TEST_F(AllreduceTest, MultipleAlgorithms) {
 }
 
 TEST_F(AllreduceTestHP, HalfPrecisionTest) {
-  int contextSize = 4;
-  auto dataSize = 1024;
-  auto fns = {
-      allreduceRingHP, allreduceRingChunkedHP, allreduceHalvingDoublingHP};
+  const auto transport = Transport::TCP;
+  const auto contextSize = 4;
+  const auto dataSize = 1024;
+  const auto fns = {
+      allreduceRingHP,
+      allreduceRingChunkedHP,
+      allreduceHalvingDoublingHP,
+  };
 
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
     const auto contextRank = context->rank;
     auto buffer = newBuffer<float16>(dataSize);
     auto* ptr = buffer.data();
@@ -229,21 +233,13 @@ TEST_F(AllreduceTestHP, HalfPrecisionTest) {
   });
 }
 
-std::vector<int> genMemorySizes() {
-  std::vector<int> v;
-  v.push_back(sizeof(float));
-  v.push_back(100);
-  v.push_back(1000);
-  v.push_back(10000);
-  return v;
-}
-
 INSTANTIATE_TEST_CASE_P(
     AllreduceRing,
     AllreduceTest,
     ::testing::Combine(
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
         ::testing::Range(1, 16),
-        ::testing::ValuesIn(genMemorySizes()),
+        ::testing::Values(4, 100, 1000, 10000),
         ::testing::Values(allreduceRing),
         ::testing::Values(0)));
 
@@ -251,8 +247,9 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceRingChunked,
     AllreduceTest,
     ::testing::Combine(
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
         ::testing::Range(1, 16),
-        ::testing::ValuesIn(genMemorySizes()),
+        ::testing::Values(4, 100, 1000, 10000),
         ::testing::Values(allreduceRingChunked),
         ::testing::Values(0)));
 
@@ -260,9 +257,9 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceHalvingDoubling,
     AllreduceTest,
     ::testing::Combine(
-        ::testing::ValuesIn(
-          std::vector<int>({1, 2, 3, 4, 5, 6, 7, 8, 9, 13, 16, 24, 32})),
-        ::testing::ValuesIn(std::vector<int>({1, 64, 1000})),
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Values(1, 2, 3, 4, 5, 6, 7, 8, 9, 13, 16, 24, 32),
+        ::testing::Values(1, 64, 1000),
         ::testing::Values(allreduceHalvingDoubling),
         ::testing::Values(0)));
 
@@ -270,9 +267,9 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceBcubeBase2,
     AllreduceTest,
     ::testing::Combine(
-        ::testing::ValuesIn(
-          std::vector<int>({1, 2, 4, 8, 16})),
-        ::testing::ValuesIn(std::vector<int>({1, 64, 1000})),
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Values(1, 2, 4, 8, 16),
+        ::testing::Values(1, 64, 1000),
         ::testing::Values(allreduceBcube),
         ::testing::Values(2)));
 
@@ -280,8 +277,9 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceBcubeBase3,
     AllreduceTest,
     ::testing::Combine(
-        ::testing::ValuesIn(std::vector<int>({1, 3, 9, 27})),
-        ::testing::ValuesIn(std::vector<int>({1, 64, 1000})),
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Values(1, 3, 9, 27),
+        ::testing::Values(1, 64, 1000),
         ::testing::Values(allreduceBcube),
         ::testing::Values(3)));
 
@@ -289,26 +287,27 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceBcubeBase4,
     AllreduceTest,
     ::testing::Combine(
-        ::testing::ValuesIn(
-          std::vector<int>({1, 4, 16})),
-        ::testing::ValuesIn(std::vector<int>({1, 64, 1000})),
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Values(1, 4, 16),
+        ::testing::Values(1, 64, 1000),
         ::testing::Values(allreduceBcube),
         ::testing::Values(4)));
 
 using Algorithm = AllreduceOptions::Algorithm;
-using NewParam = std::tuple<int, int, int, bool, Algorithm>;
+using NewParam = std::tuple<Transport, int, int, int, bool, Algorithm>;
 
 class AllreduceNewTest : public BaseTest,
                          public ::testing::WithParamInterface<NewParam> {};
 
 TEST_P(AllreduceNewTest, Default) {
-  auto contextSize = std::get<0>(GetParam());
-  auto numPointers = std::get<1>(GetParam());
-  auto dataSize = std::get<2>(GetParam());
-  auto inPlace = std::get<3>(GetParam());
-  auto algorithm = std::get<4>(GetParam());
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  const auto numPointers = std::get<2>(GetParam());
+  const auto dataSize = std::get<3>(GetParam());
+  const auto inPlace = std::get<4>(GetParam());
+  const auto algorithm = std::get<5>(GetParam());
 
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
     Fixture<uint64_t> inputs(context, numPointers, dataSize);
     Fixture<uint64_t> outputs(context, numPointers, dataSize);
 
@@ -345,7 +344,7 @@ TEST_P(AllreduceNewTest, Default) {
     for (auto j = 0; j < numPointers; j++) {
       for (auto k = 0; k < dataSize; k++) {
         ASSERT_EQ(k * stride * stride + base, out[j][k])
-          << "Mismatch at out[" << j << "][" << k << "]";
+            << "Mismatch at out[" << j << "][" << k << "]";
       }
     }
   });
@@ -355,6 +354,7 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceNewRing,
     AllreduceNewTest,
     ::testing::Combine(
+        ::testing::ValuesIn(kTransportsForFunctionAlgorithms),
         ::testing::Values(1, 2, 4, 7),
         ::testing::Values(1, 2, 3),
         ::testing::Values(1, 10, 100, 1000, 10000),
@@ -365,6 +365,7 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceNewBcube,
     AllreduceNewTest,
     ::testing::Combine(
+        ::testing::ValuesIn(kTransportsForFunctionAlgorithms),
         ::testing::Values(1, 2, 4, 7),
         ::testing::Values(1, 2, 3),
         ::testing::Values(1, 10, 100, 1000, 10000),
@@ -378,7 +379,7 @@ AllreduceOptions::Func getFunction() {
 }
 
 TEST_F(AllreduceNewTest, TestTimeout) {
-  spawn(2, [&](std::shared_ptr<Context> context) {
+  spawn(Transport::TCP, 2, [&](std::shared_ptr<Context> context) {
     Fixture<uint64_t> outputs(context, 1, 1);
     AllreduceOptions opts(context);
     opts.setOutputs(outputs.getPointers(), 1);

--- a/gloo/test/base_test.h
+++ b/gloo/test/base_test.h
@@ -48,6 +48,22 @@ class Barrier {
   std::condition_variable cv_;
 };
 
+enum Transport {
+  TCP,
+};
+
+// Transports that instantiated algorithms can be tested against.
+const std::vector<Transport> kTransportsForClassAlgorithms{
+    Transport::TCP,
+};
+
+// Transports that function algorithms can be tested against.
+// This is the new style of calling collectives and must be
+// preferred over the instantiated style.
+const std::vector<Transport> kTransportsForFunctionAlgorithms{
+    Transport::TCP,
+};
+
 class BaseTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
@@ -82,6 +98,7 @@ class BaseTest : public ::testing::Test {
   }
 
   void spawn(
+      Transport transport,
       int size,
       std::function<void(std::shared_ptr<Context>)> fn,
       int base = 2) {
@@ -241,8 +258,10 @@ class Fixture<float16> {
     }
   }
 
-  void
-  checkBroadcastResult(Fixture<float16>& fixture, int root, int rootPointer) {
+  void checkBroadcastResult(
+      Fixture<float16>& fixture,
+      int root,
+      int rootPointer) {
     // Expected is set to the expected value at ptr[0]
     const auto expected = root * fixture.srcs.size() + rootPointer;
     // Stride is difference between values at subsequent indices
@@ -352,8 +371,10 @@ class Fixture<float> {
     }
   }
 
-  void
-  checkBroadcastResult(Fixture<float>& fixture, int root, int rootPointer) {
+  void checkBroadcastResult(
+      Fixture<float>& fixture,
+      int root,
+      int rootPointer) {
     // Expected is set to the expected value at ptr[0]
     const auto expected = root * fixture.srcs.size() + rootPointer;
     // Stride is difference between values at subsequent indices

--- a/gloo/test/base_test.h
+++ b/gloo/test/base_test.h
@@ -69,7 +69,7 @@ class BaseTest : public ::testing::Test {
   virtual void SetUp() {
 #if GLOO_HAVE_TRANSPORT_TCP
     static auto dev = ::gloo::transport::tcp::CreateDevice("localhost");
-    return dev;
+    device_ = dev;
 #endif
     GLOO_ENFORCE(device_, "No transport device!");
   }

--- a/gloo/test/base_test.h
+++ b/gloo/test/base_test.h
@@ -68,7 +68,8 @@ class BaseTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
 #if GLOO_HAVE_TRANSPORT_TCP
-    device_ = ::gloo::transport::tcp::CreateDevice("localhost");
+    static auto dev = ::gloo::transport::tcp::CreateDevice("localhost");
+    return dev;
 #endif
     GLOO_ENFORCE(device_, "No transport device!");
   }

--- a/gloo/test/broadcast_test.cc
+++ b/gloo/test/broadcast_test.cc
@@ -27,7 +27,7 @@ using Func = std::unique_ptr<::gloo::Algorithm>(
     int rootPointerRank);
 
 // Test parameterization.
-using Param = std::tuple<int, int, size_t, std::function<Func>>;
+using Param = std::tuple<Transport, int, int, size_t, std::function<Func>>;
 
 // Test fixture.
 class BroadcastTest : public BaseTest,
@@ -41,157 +41,142 @@ class BroadcastTest : public BaseTest,
     // Verify all buffers passed by this instance
     for (const auto& ptr : fixture.getPointers()) {
       for (auto i = 0; i < fixture.count; i++) {
-        ASSERT_EQ((i * stride) + expected, ptr[i])
-          << "Mismatch at index " << i;
+        ASSERT_EQ((i * stride) + expected, ptr[i]) << "Mismatch at index " << i;
       }
     }
   }
 };
 
 TEST_P(BroadcastTest, Default) {
-  auto processCount = std::get<0>(GetParam());
-  auto pointerCount = std::get<1>(GetParam());
-  auto elementCount = std::get<2>(GetParam());
-  auto fn = std::get<3>(GetParam());
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  const auto numPointers = std::get<2>(GetParam());
+  const auto dataSize = std::get<3>(GetParam());
+  const auto fn = std::get<4>(GetParam());
 
-  spawn(processCount, [&](std::shared_ptr<Context> context) {
-      auto fixture = Fixture<float>(context, pointerCount, elementCount);
-      auto ptrs = fixture.getPointers();
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    auto fixture = Fixture<float>(context, numPointers, dataSize);
+    auto ptrs = fixture.getPointers();
 
-      // Run with varying root
-      // TODO(PN): go up to processCount
-      for (auto rootProcessRank = 0;
-           rootProcessRank < 1;
-           rootProcessRank++) {
-        // TODO(PN): go up to pointerCount
-        for (auto rootPointerRank = 0;
-             rootPointerRank < 1;
-             rootPointerRank++) {
-          fixture.assignValues();
-          auto algorithm = fn(context,
-                              ptrs,
-                              elementCount,
-                              rootProcessRank,
-                              rootPointerRank);
-          algorithm->run();
+    // Run with varying root
+    // TODO(PN): go up to contextSize
+    for (auto rootProcessRank = 0; rootProcessRank < 1; rootProcessRank++) {
+      // TODO(PN): go up to numPointers
+      for (auto rootPointerRank = 0; rootPointerRank < 1; rootPointerRank++) {
+        fixture.assignValues();
+        auto algorithm =
+            fn(context, ptrs, dataSize, rootProcessRank, rootPointerRank);
+        algorithm->run();
 
-          // Verify result
-          assertResult(fixture, rootProcessRank, rootPointerRank);
-        }
+        // Verify result
+        assertResult(fixture, rootProcessRank, rootPointerRank);
       }
-    });
+    }
+  });
 }
 
-std::vector<size_t> genMemorySizes() {
-  std::vector<size_t> v;
-  v.push_back(sizeof(float));
-  v.push_back(100);
-  v.push_back(1000);
-  v.push_back(10000);
-  return v;
-}
-
-static std::function<Func> broadcastOneToAll = [](
-    std::shared_ptr<::gloo::Context>& context,
-    std::vector<float*> ptrs,
-    size_t count,
-    int rootProcessRank,
-    int rootPointerRank) {
-  return std::unique_ptr<::gloo::Algorithm>(
-    new ::gloo::BroadcastOneToAll<float>(
-      context, ptrs, count, rootProcessRank, rootPointerRank));
-};
+static std::function<Func> broadcastOneToAll =
+    [](std::shared_ptr<::gloo::Context>& context,
+       std::vector<float*> ptrs,
+       size_t count,
+       int rootProcessRank,
+       int rootPointerRank) {
+      return std::unique_ptr<::gloo::Algorithm>(
+          new ::gloo::BroadcastOneToAll<float>(
+              context, ptrs, count, rootProcessRank, rootPointerRank));
+    };
 
 INSTANTIATE_TEST_CASE_P(
     OneToAllBroadcast,
     BroadcastTest,
     ::testing::Combine(
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
         ::testing::Values(2, 3, 4, 5),
         ::testing::Values(1, 2),
-        ::testing::ValuesIn(genMemorySizes()),
+        ::testing::Values(4, 100, 1000, 10000),
         ::testing::Values(broadcastOneToAll)));
 
 INSTANTIATE_TEST_CASE_P(
     LargeBroadcast,
     BroadcastTest,
     ::testing::Combine(
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
         ::testing::Values(2),
         ::testing::Values(1),
         ::testing::Values(512 * 1024 * 1024),
         ::testing::Values(broadcastOneToAll)));
 
-using NewParam = std::tuple<int, int, bool, bool>;
+using NewParam = std::tuple<Transport, int, int, bool, bool>;
 
 class BroadcastNewTest : public BaseTest,
                          public ::testing::WithParamInterface<NewParam> {};
 
 TEST_P(BroadcastNewTest, Default) {
-  auto contextSize = std::get<0>(GetParam());
-  auto dataSize = std::get<1>(GetParam());
-  auto passBuffers = std::get<2>(GetParam());
-  auto inPlace = std::get<3>(GetParam());
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  const auto dataSize = std::get<2>(GetParam());
+  const auto passBuffers = std::get<3>(GetParam());
+  const auto inPlace = std::get<4>(GetParam());
 
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
-      auto input = Fixture<uint64_t>(context, 1, dataSize);
-      auto output = Fixture<uint64_t>(context, 1, dataSize);
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    auto input = Fixture<uint64_t>(context, 1, dataSize);
+    auto output = Fixture<uint64_t>(context, 1, dataSize);
 
-      // Take turns being root
-      for (auto root = 0; root < context->size; root++) {
-        BroadcastOptions opts(context);
-        opts.setRoot(root);
+    // Take turns being root
+    for (auto root = 0; root < context->size; root++) {
+      BroadcastOptions opts(context);
+      opts.setRoot(root);
 
-        input.clear();
-        output.clear();
+      input.clear();
+      output.clear();
 
-        if (context->rank == root) {
-          if (inPlace) {
-            // If in place, use output as input
-            output.assignValues();
+      if (context->rank == root) {
+        if (inPlace) {
+          // If in place, use output as input
+          output.assignValues();
+        } else {
+          // If not in place, use separate input
+          input.assignValues();
+          if (passBuffers) {
+            opts.setInput<uint64_t>(context->createUnboundBuffer(
+                input.getPointer(), dataSize * sizeof(uint64_t)));
           } else {
-            // If not in place, use separate input
-            input.assignValues();
-            if (passBuffers) {
-              opts.setInput<uint64_t>(context->createUnboundBuffer(
-                  input.getPointer(),
-                  dataSize * sizeof(uint64_t)));
-            } else {
-              opts.setInput(input.getPointer(), dataSize);
-            }
+            opts.setInput(input.getPointer(), dataSize);
           }
         }
-
-        if (passBuffers) {
-          opts.setOutput<uint64_t>(context->createUnboundBuffer(
-              output.getPointer(),
-              dataSize * sizeof(uint64_t)));
-        } else {
-          opts.setOutput(output.getPointer(), dataSize);
-        }
-
-        broadcast(opts);
-
-        // Validate output
-        const auto ptr = output.getPointer();
-        const auto stride = context->size;
-        for (auto k = 0; k < dataSize; k++) {
-          ASSERT_EQ(root + k * stride, ptr[k])
-            << "Mismatch at index " << k;
-        }
       }
-    });
+
+      if (passBuffers) {
+        opts.setOutput<uint64_t>(context->createUnboundBuffer(
+            output.getPointer(), dataSize * sizeof(uint64_t)));
+      } else {
+        opts.setOutput(output.getPointer(), dataSize);
+      }
+
+      broadcast(opts);
+
+      // Validate output
+      const auto ptr = output.getPointer();
+      const auto stride = context->size;
+      for (auto k = 0; k < dataSize; k++) {
+        ASSERT_EQ(root + k * stride, ptr[k]) << "Mismatch at index " << k;
+      }
+    }
+  });
 }
 
 INSTANTIATE_TEST_CASE_P(
     BroadcastNewDefault,
     BroadcastNewTest,
     ::testing::Combine(
+        ::testing::ValuesIn(kTransportsForFunctionAlgorithms),
         ::testing::Values(1, 2, 4, 7),
         ::testing::Values(1, 10, 100),
         ::testing::Values(false, true),
         ::testing::Values(false, true)));
 
 TEST_F(BroadcastTest, TestTimeout) {
-  spawn(2, [&](std::shared_ptr<Context> context) {
+  spawn(Transport::TCP, 2, [&](std::shared_ptr<Context> context) {
     Fixture<uint64_t> output(context, 1, 1);
     BroadcastOptions opts(context);
     opts.setOutput(output.getPointer(), 1);

--- a/gloo/test/buffer_test.cc
+++ b/gloo/test/buffer_test.cc
@@ -23,43 +23,43 @@ TEST_F(BufferTest, RemoteOffset) {
   constexpr auto processCount = 2;
 
   spawn(processCount, [&](std::shared_ptr<Context> context) {
-      std::array<float, processCount> data;
-      std::unique_ptr<transport::Buffer> sendBuffer;
-      std::unique_ptr<transport::Buffer> recvBuffer;
+    std::array<float, processCount> data;
+    std::unique_ptr<transport::Buffer> sendBuffer;
+    std::unique_ptr<transport::Buffer> recvBuffer;
 
-      if (context->rank == 0) {
-        auto& other = context->getPair(1);
-        sendBuffer = other->createSendBuffer(
-          0, data.data(), data.size() * sizeof(float));
-        recvBuffer = other->createRecvBuffer(
-          1, data.data(), data.size() * sizeof(float));
-      }
-      if (context->rank == 1) {
-        auto& other = context->getPair(0);
-        recvBuffer = other->createRecvBuffer(
-          0, data.data(), data.size() * sizeof(float));
-        sendBuffer = other->createSendBuffer(
-          1, data.data(), data.size() * sizeof(float));
-      }
+    if (context->rank == 0) {
+      auto& other = context->getPair(1);
+      sendBuffer =
+          other->createSendBuffer(0, data.data(), data.size() * sizeof(float));
+      recvBuffer =
+          other->createRecvBuffer(1, data.data(), data.size() * sizeof(float));
+    }
+    if (context->rank == 1) {
+      auto& other = context->getPair(0);
+      recvBuffer =
+          other->createRecvBuffer(0, data.data(), data.size() * sizeof(float));
+      sendBuffer =
+          other->createSendBuffer(1, data.data(), data.size() * sizeof(float));
+    }
 
-      // Set value indexed on this process' rank
-      data[context->rank] = context->rank + 1000;
+    // Set value indexed on this process' rank
+    data[context->rank] = context->rank + 1000;
 
-      // Send value to the remote buffer (using offset)
-      auto offset = context->rank * sizeof(float);
-      sendBuffer->send(offset, sizeof(float), offset);
-      sendBuffer->waitSend();
+    // Send value to the remote buffer (using offset)
+    auto offset = context->rank * sizeof(float);
+    sendBuffer->send(offset, sizeof(float), offset);
+    sendBuffer->waitSend();
 
-      // Wait for receive
-      recvBuffer->waitRecv();
+    // Wait for receive
+    recvBuffer->waitRecv();
 
-      // Both processes have written to each other's buffer
-      // at an offset equal to their rank. Their buffers now
-      // contain the same values.
-      for (auto i = 0; i < data.size(); i++) {
-        ASSERT_EQ(1000 + i, data[i]);
-      }
-    });
+    // Both processes have written to each other's buffer
+    // at an offset equal to their rank. Their buffers now
+    // contain the same values.
+    for (auto i = 0; i < data.size(); i++) {
+      ASSERT_EQ(1000 + i, data[i]);
+    }
+  });
 }
 
 } // namespace

--- a/gloo/test/context_factory_test.cc
+++ b/gloo/test/context_factory_test.cc
@@ -34,28 +34,28 @@ TEST_P(ContextStoreTest, RunAlgo) {
   auto fn = std::get<2>(GetParam());
 
   spawn(contextSize, [&](std::shared_ptr<Context> context) {
-      auto factory = std::make_shared<::gloo::rendezvous::ContextFactory>(
-        context);
-      for (int i = 0; i < repeatCount; ++i) {
-        auto usingContext = factory->makeContext(device_);
-        fn(usingContext);
-      }
-    });
+    auto factory =
+        std::make_shared<::gloo::rendezvous::ContextFactory>(context);
+    for (int i = 0; i < repeatCount; ++i) {
+      auto usingContext = factory->makeContext(device_);
+      fn(usingContext);
+    }
+  });
 }
 
 static std::function<Func> barrierAllToAll =
-  [](std::shared_ptr<::gloo::Context> context) {
-  ::gloo::BarrierAllToAll algorithm(context);
-  algorithm.run();
-};
+    [](std::shared_ptr<::gloo::Context> context) {
+      ::gloo::BarrierAllToAll algorithm(context);
+      algorithm.run();
+    };
 
 INSTANTIATE_TEST_CASE_P(
-  BarrierAllToAll,
-  ContextStoreTest,
-  ::testing::Combine(
-    ::testing::Range(2, 4),
-    ::testing::Values(10),
-    ::testing::Values(barrierAllToAll)));
+    BarrierAllToAll,
+    ContextStoreTest,
+    ::testing::Combine(
+        ::testing::Range(2, 4),
+        ::testing::Values(10),
+        ::testing::Values(barrierAllToAll)));
 } // namespace
 } // namespace test
 } // namespace gloo

--- a/gloo/test/cuda_allreduce_test.cc
+++ b/gloo/test/cuda_allreduce_test.cc
@@ -35,8 +35,8 @@ using Func16 = std::unique_ptr<::gloo::Algorithm>(
     std::vector<cudaStream_t> streams);
 
 // Test parameterization.
-using Param = std::tuple<int, int, std::function<Func>, int>;
-using ParamHP = std::tuple<int, int, std::function<Func16>>;
+using Param = std::tuple<Transport, int, int, std::function<Func>, int>;
+using ParamHP = std::tuple<Transport, int, int, std::function<Func16>>;
 
 // Test case
 class CudaAllreduceTest : public CudaBaseTest,
@@ -57,52 +57,54 @@ class CudaAllreduceTestHP : public CudaBaseTest,
   }
 };
 
-static std::function<Func> allreduceRing = [](
-    std::shared_ptr<::gloo::Context>& context,
-    std::vector<float*> ptrs,
-    int count,
-    std::vector<cudaStream_t> streams) {
-  return std::unique_ptr<::gloo::Algorithm>(
-    new ::gloo::CudaAllreduceRing<float>(context, ptrs, count, streams));
-};
+static std::function<Func> allreduceRing =
+    [](std::shared_ptr<::gloo::Context>& context,
+       std::vector<float*> ptrs,
+       int count,
+       std::vector<cudaStream_t> streams) {
+      return std::unique_ptr<::gloo::Algorithm>(
+          new ::gloo::CudaAllreduceRing<float>(context, ptrs, count, streams));
+    };
 
-static std::function<Func16> allreduceRingHP = [](
-    std::shared_ptr<::gloo::Context>& context,
-    std::vector<float16*> ptrs,
-    int count,
-    std::vector<cudaStream_t> streams) {
-  return std::unique_ptr<::gloo::Algorithm>(
-    new ::gloo::CudaAllreduceRing<float16>(context, ptrs, count, streams));
-};
+static std::function<Func16> allreduceRingHP =
+    [](std::shared_ptr<::gloo::Context>& context,
+       std::vector<float16*> ptrs,
+       int count,
+       std::vector<cudaStream_t> streams) {
+      return std::unique_ptr<::gloo::Algorithm>(
+          new ::gloo::CudaAllreduceRing<float16>(
+              context, ptrs, count, streams));
+    };
 
-static std::function<Func> allreduceRingChunked = [](
-    std::shared_ptr<::gloo::Context>& context,
-    std::vector<float*> ptrs,
-    int count,
-    std::vector<cudaStream_t> streams) {
-  return std::unique_ptr<::gloo::Algorithm>(
-    new ::gloo::CudaAllreduceRingChunked<float>(context, ptrs, count, streams));
-};
+static std::function<Func> allreduceRingChunked =
+    [](std::shared_ptr<::gloo::Context>& context,
+       std::vector<float*> ptrs,
+       int count,
+       std::vector<cudaStream_t> streams) {
+      return std::unique_ptr<::gloo::Algorithm>(
+          new ::gloo::CudaAllreduceRingChunked<float>(
+              context, ptrs, count, streams));
+    };
 
-static std::function<Func16> allreduceRingChunkedHP = [](
-    std::shared_ptr<::gloo::Context>& context,
-    std::vector<float16*> ptrs,
-    int count,
-    std::vector<cudaStream_t> streams) {
-  return std::unique_ptr<::gloo::Algorithm>(
-      new ::gloo::CudaAllreduceRingChunked<float16>(
-          context, ptrs, count, streams));
-};
+static std::function<Func16> allreduceRingChunkedHP =
+    [](std::shared_ptr<::gloo::Context>& context,
+       std::vector<float16*> ptrs,
+       int count,
+       std::vector<cudaStream_t> streams) {
+      return std::unique_ptr<::gloo::Algorithm>(
+          new ::gloo::CudaAllreduceRingChunked<float16>(
+              context, ptrs, count, streams));
+    };
 
-static std::function<Func> allreduceHalvingDoubling = [](
-    std::shared_ptr<::gloo::Context>& context,
-    std::vector<float*> ptrs,
-    int count,
-    std::vector<cudaStream_t> streams) {
-  return std::unique_ptr<::gloo::Algorithm>(
-      new ::gloo::CudaAllreduceHalvingDoubling<float>(
-          context, ptrs, count, streams));
-};
+static std::function<Func> allreduceHalvingDoubling =
+    [](std::shared_ptr<::gloo::Context>& context,
+       std::vector<float*> ptrs,
+       int count,
+       std::vector<cudaStream_t> streams) {
+      return std::unique_ptr<::gloo::Algorithm>(
+          new ::gloo::CudaAllreduceHalvingDoubling<float>(
+              context, ptrs, count, streams));
+    };
 
 static std::function<Func> allreduceBcube =
     [](std::shared_ptr<::gloo::Context>& context,
@@ -113,49 +115,51 @@ static std::function<Func> allreduceBcube =
           new ::gloo::CudaAllreduceBcube<float>(context, ptrs, count, streams));
     };
 
-static std::function<Func16> allreduceHalvingDoublingHP = [](
-    std::shared_ptr<::gloo::Context>& context,
-    std::vector<float16*> ptrs,
-    int count,
-    std::vector<cudaStream_t> streams) {
-  return std::unique_ptr<::gloo::Algorithm>(
-      new ::gloo::CudaAllreduceHalvingDoubling<float16>(
-          context, ptrs, count, streams));
-};
+static std::function<Func16> allreduceHalvingDoublingHP =
+    [](std::shared_ptr<::gloo::Context>& context,
+       std::vector<float16*> ptrs,
+       int count,
+       std::vector<cudaStream_t> streams) {
+      return std::unique_ptr<::gloo::Algorithm>(
+          new ::gloo::CudaAllreduceHalvingDoubling<float16>(
+              context, ptrs, count, streams));
+    };
 
-static std::function<Func> allreduceHalvingDoublingPipelined = [](
-    std::shared_ptr<::gloo::Context>& context,
-    std::vector<float*> ptrs,
-    int count,
-    std::vector<cudaStream_t> streams) {
-  return std::unique_ptr<::gloo::Algorithm>(
-      new ::gloo::CudaAllreduceHalvingDoublingPipelined<float>(
-          context, ptrs, count, streams));
-};
+static std::function<Func> allreduceHalvingDoublingPipelined =
+    [](std::shared_ptr<::gloo::Context>& context,
+       std::vector<float*> ptrs,
+       int count,
+       std::vector<cudaStream_t> streams) {
+      return std::unique_ptr<::gloo::Algorithm>(
+          new ::gloo::CudaAllreduceHalvingDoublingPipelined<float>(
+              context, ptrs, count, streams));
+    };
 
-static std::function<Func16> allreduceHalvingDoublingPipelinedHP = [](
-    std::shared_ptr<::gloo::Context>& context,
-    std::vector<float16*> ptrs,
-    int count,
-    std::vector<cudaStream_t> streams) {
-  return std::unique_ptr<::gloo::Algorithm>(
-      new ::gloo::CudaAllreduceHalvingDoublingPipelined<float16>(
-          context, ptrs, count, streams));
-};
+static std::function<Func16> allreduceHalvingDoublingPipelinedHP =
+    [](std::shared_ptr<::gloo::Context>& context,
+       std::vector<float16*> ptrs,
+       int count,
+       std::vector<cudaStream_t> streams) {
+      return std::unique_ptr<::gloo::Algorithm>(
+          new ::gloo::CudaAllreduceHalvingDoublingPipelined<float16>(
+              context, ptrs, count, streams));
+    };
 
 TEST_P(CudaAllreduceTest, SinglePointer) {
-  auto size = std::get<0>(GetParam());
-  auto count = std::get<1>(GetParam());
-  auto fn = std::get<2>(GetParam());
-  auto base = std::get<3>(GetParam());
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  const auto dataSize = std::get<2>(GetParam());
+  const auto fn = std::get<3>(GetParam());
+  const auto base = std::get<4>(GetParam());
 
   spawn(
-      size,
+      transport,
+      contextSize,
       [&](std::shared_ptr<Context> context) {
         // Run algorithm
-        auto fixture = CudaFixture<float>(context, 1, count);
+        auto fixture = CudaFixture<float>(context, 1, dataSize);
         auto ptrs = fixture.getCudaPointers();
-        auto algorithm = fn(context, ptrs, count, {});
+        auto algorithm = fn(context, ptrs, dataSize, {});
         fixture.assignValues();
         algorithm->run();
 
@@ -166,67 +170,78 @@ TEST_P(CudaAllreduceTest, SinglePointer) {
 }
 
 TEST_P(CudaAllreduceTest, MultiPointer) {
-  auto size = std::get<0>(GetParam());
-  auto count = std::get<1>(GetParam());
-  auto fn = std::get<2>(GetParam());
-  auto base = std::get<3>(GetParam());
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  const auto dataSize = std::get<2>(GetParam());
+  const auto fn = std::get<3>(GetParam());
+  const auto base = std::get<4>(GetParam());
 
-  spawn(size, [&](std::shared_ptr<Context> context) {
-      // Run algorithm
-      auto fixture = CudaFixture<float>(context, cudaNumDevices(), count);
-      auto ptrs = fixture.getCudaPointers();
-      auto algorithm = fn(context, ptrs, count, {});
-      fixture.assignValues();
-      algorithm->run();
+  spawn(
+      transport,
+      contextSize,
+      [&](std::shared_ptr<Context> context) {
+        // Run algorithm
+        auto fixture = CudaFixture<float>(context, cudaNumDevices(), dataSize);
+        auto ptrs = fixture.getCudaPointers();
+        auto algorithm = fn(context, ptrs, dataSize, {});
+        fixture.assignValues();
+        algorithm->run();
 
-      // Verify result
-      assertResult(fixture);
-    }, base);
+        // Verify result
+        assertResult(fixture);
+      },
+      base);
 }
 
 TEST_P(CudaAllreduceTest, MultiPointerAsync) {
-  auto size = std::get<0>(GetParam());
-  auto count = std::get<1>(GetParam());
-  auto fn = std::get<2>(GetParam());
-  auto base = std::get<3>(GetParam());
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  const auto dataSize = std::get<2>(GetParam());
+  const auto fn = std::get<3>(GetParam());
+  const auto base = std::get<4>(GetParam());
 
-  spawn(size, [&](std::shared_ptr<Context> context) {
-      // Run algorithm
-      auto fixture = CudaFixture<float>(context, cudaNumDevices(), count);
-      auto ptrs = fixture.getCudaPointers();
-      auto streams = fixture.getCudaStreams();
-      auto algorithm = fn(context, ptrs, count, streams);
-      fixture.assignValuesAsync();
-      algorithm->run();
+  spawn(
+      contextSize,
+      [&](std::shared_ptr<Context> context) {
+        // Run algorithm
+        auto fixture = CudaFixture<float>(context, cudaNumDevices(), dataSize);
+        auto ptrs = fixture.getCudaPointers();
+        auto streams = fixture.getCudaStreams();
+        auto algorithm = fn(context, ptrs, dataSize, streams);
+        fixture.assignValuesAsync();
+        algorithm->run();
 
-      // Verify result
-      fixture.synchronizeCudaStreams();
-      assertResult(fixture);
-    }, base);
+        // Verify result
+        fixture.synchronizeCudaStreams();
+        assertResult(fixture);
+      },
+      base);
 }
 
 TEST_F(CudaAllreduceTest, MultipleAlgorithms) {
-  auto size = 4;
-  auto count = 1000;
-  auto fns = {allreduceRing,
-             allreduceRingChunked,
-             allreduceHalvingDoubling,
-             allreduceHalvingDoublingPipelined};
+  const auto contextSize = 4;
+  const auto dataSize = 1000;
+  const auto fns = {
+      allreduceRing,
+      allreduceRingChunked,
+      allreduceHalvingDoubling,
+      allreduceHalvingDoublingPipelined,
+  };
 
-  spawn(size, [&](std::shared_ptr<Context> context) {
+  spawn(contextSize, [&](std::shared_ptr<Context> context) {
     for (const auto& fn : fns) {
       // Run algorithm
-      auto fixture = CudaFixture<float>(context, 1, count);
+      auto fixture = CudaFixture<float>(context, 1, dataSize);
       auto ptrs = fixture.getCudaPointers();
 
-      auto algorithm = fn(context, ptrs, count, {});
+      auto algorithm = fn(context, ptrs, dataSize, {});
       fixture.assignValues();
       algorithm->run();
 
       // Verify result
       assertResult(fixture);
 
-      auto algorithm2 = fn(context, ptrs, count, {});
+      auto algorithm2 = fn(context, ptrs, dataSize, {});
       fixture.assignValues();
       algorithm2->run();
 
@@ -237,62 +252,58 @@ TEST_F(CudaAllreduceTest, MultipleAlgorithms) {
 }
 
 TEST_F(CudaAllreduceTestHP, HalfPrecisionTest) {
-  auto size = 4;
-  auto count = 128;
-  auto fns = {allreduceRingHP,
-             allreduceRingChunkedHP,
-             allreduceHalvingDoublingHP,
-             allreduceHalvingDoublingPipelinedHP};
-  spawn(size, [&](std::shared_ptr<Context> context) {
-      for (const auto& fn : fns) {
-        // Run algorithm
-        auto fixture = CudaFixture<float16>(context, 1, count);
-        auto ptrs = fixture.getCudaPointers();
+  const auto contextSize = 4;
+  const auto dataSize = 128;
+  const auto fns = {
+      allreduceRingHP,
+      allreduceRingChunkedHP,
+      allreduceHalvingDoublingHP,
+      allreduceHalvingDoublingPipelinedHP,
+  };
 
-        auto algorithm = fn(context, ptrs, count, {});
-        fixture.assignValues();
-        algorithm->run();
+  spawn(Transport::TCP, contextSize, [&](std::shared_ptr<Context> context) {
+    for (const auto& fn : fns) {
+      // Run algorithm
+      auto fixture = CudaFixture<float16>(context, 1, count);
+      auto ptrs = fixture.getCudaPointers();
 
-        // Verify result
-        assertResult(fixture);
-      }
-    });
-}
+      auto algorithm = fn(context, ptrs, count, {});
+      fixture.assignValues();
+      algorithm->run();
 
-std::vector<int> genMemorySizes() {
-  std::vector<int> v;
-  v.push_back(sizeof(float));
-  v.push_back(100);
-  v.push_back(1000);
-  v.push_back(10000);
-  return v;
+      // Verify result
+      assertResult(fixture);
+    }
+  });
 }
 
 INSTANTIATE_TEST_CASE_P(
     AllreduceRing,
     CudaAllreduceTest,
     ::testing::Combine(
-      ::testing::Range(1, 16),
-      ::testing::ValuesIn(genMemorySizes()),
-      ::testing::Values(allreduceRing),
-      ::testing::Values(0)));
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Range(1, 16),
+        ::testing::Values(4, 100, 1000, 10000),
+        ::testing::Values(allreduceRing),
+        ::testing::Values(0)));
 
 INSTANTIATE_TEST_CASE_P(
     AllreduceRingChunked,
     CudaAllreduceTest,
     ::testing::Combine(
-      ::testing::Range(1, 16),
-      ::testing::ValuesIn(genMemorySizes()),
-      ::testing::Values(allreduceRingChunked),
-      ::testing::Values(0)));
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Range(1, 16),
+        ::testing::Values(4, 100, 1000, 10000),
+        ::testing::Values(allreduceRingChunked),
+        ::testing::Values(0)));
 
 INSTANTIATE_TEST_CASE_P(
     AllreduceHalvingDoubling,
     CudaAllreduceTest,
     ::testing::Combine(
-        ::testing::ValuesIn(
-          std::vector<int>({1, 2, 3, 4, 5, 6, 7, 8, 9, 13, 16, 24, 32})),
-        ::testing::ValuesIn(std::vector<int>({1, 64, 1000})),
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Values(1, 2, 3, 4, 5, 6, 7, 8, 9, 13, 16, 24, 32),
+        ::testing::Values(1, 64, 1000),
         ::testing::Values(allreduceHalvingDoubling),
         ::testing::Values(0)));
 
@@ -300,9 +311,9 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceBcubeBase2,
     CudaAllreduceTest,
     ::testing::Combine(
-        ::testing::ValuesIn(
-          std::vector<int>({1, 2, 4, 8, 16})),
-        ::testing::ValuesIn(std::vector<int>({1, 64, 1000})),
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Values(1, 2, 4, 8, 16),
+        ::testing::Values(1, 64, 1000),
         ::testing::Values(allreduceBcube),
         ::testing::Values(2)));
 
@@ -310,8 +321,9 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceBcubeBase3,
     CudaAllreduceTest,
     ::testing::Combine(
-        ::testing::ValuesIn(std::vector<int>({1, 3, 9, 27})),
-        ::testing::ValuesIn(std::vector<int>({1, 64, 1000})),
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Values(1, 3, 9, 27),
+        ::testing::Values(1, 64, 1000),
         ::testing::Values(allreduceBcube),
         ::testing::Values(3)));
 
@@ -319,8 +331,9 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceBcubeBase4,
     CudaAllreduceTest,
     ::testing::Combine(
-        ::testing::ValuesIn(std::vector<int>({1, 4, 16})),
-        ::testing::ValuesIn(std::vector<int>({1, 64, 1000})),
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Values(1, 4, 16),
+        ::testing::Values(1, 64, 1000),
         ::testing::Values(allreduceBcube),
         ::testing::Values(4)));
 
@@ -328,9 +341,9 @@ INSTANTIATE_TEST_CASE_P(
     AllreduceHalvingDoublingPipelined,
     CudaAllreduceTest,
     ::testing::Combine(
-        ::testing::ValuesIn(
-          std::vector<int>({1, 2, 3, 4, 5, 6, 7, 8, 9, 13, 16, 24, 32})),
-        ::testing::ValuesIn(std::vector<int>({1, 64, 1000})),
+        ::testing::ValuesIn(kTransportsForClassAlgorithms),
+        ::testing::Values(1, 2, 3, 4, 5, 6, 7, 8, 9, 13, 16, 24, 32),
+        ::testing::Values(1, 64, 1000),
         ::testing::Values(allreduceHalvingDoublingPipelined),
         ::testing::Values(0)));
 

--- a/gloo/test/cuda_allreduce_test.cc
+++ b/gloo/test/cuda_allreduce_test.cc
@@ -201,6 +201,7 @@ TEST_P(CudaAllreduceTest, MultiPointerAsync) {
   const auto base = std::get<4>(GetParam());
 
   spawn(
+    transport,
       contextSize,
       [&](std::shared_ptr<Context> context) {
         // Run algorithm
@@ -228,7 +229,7 @@ TEST_F(CudaAllreduceTest, MultipleAlgorithms) {
       allreduceHalvingDoublingPipelined,
   };
 
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
     for (const auto& fn : fns) {
       // Run algorithm
       auto fixture = CudaFixture<float>(context, 1, dataSize);
@@ -264,10 +265,10 @@ TEST_F(CudaAllreduceTestHP, HalfPrecisionTest) {
   spawn(Transport::TCP, contextSize, [&](std::shared_ptr<Context> context) {
     for (const auto& fn : fns) {
       // Run algorithm
-      auto fixture = CudaFixture<float16>(context, 1, count);
+      auto fixture = CudaFixture<float16>(context, 1, dataSize);
       auto ptrs = fixture.getCudaPointers();
 
-      auto algorithm = fn(context, ptrs, count, {});
+      auto algorithm = fn(context, ptrs, dataSize, {});
       fixture.assignValues();
       algorithm->run();
 

--- a/gloo/test/cuda_allreduce_test.cc
+++ b/gloo/test/cuda_allreduce_test.cc
@@ -201,7 +201,7 @@ TEST_P(CudaAllreduceTest, MultiPointerAsync) {
   const auto base = std::get<4>(GetParam());
 
   spawn(
-    transport,
+      transport,
       contextSize,
       [&](std::shared_ptr<Context> context) {
         // Run algorithm

--- a/gloo/test/cuda_allreduce_test.cc
+++ b/gloo/test/cuda_allreduce_test.cc
@@ -229,7 +229,7 @@ TEST_F(CudaAllreduceTest, MultipleAlgorithms) {
       allreduceHalvingDoublingPipelined,
   };
 
-  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+  spawn(Transport::TCP, contextSize, [&](std::shared_ptr<Context> context) {
     for (const auto& fn : fns) {
       // Run algorithm
       auto fixture = CudaFixture<float>(context, 1, dataSize);

--- a/gloo/test/cuda_base_test.h
+++ b/gloo/test/cuda_base_test.h
@@ -11,7 +11,6 @@
 #include "gloo/cuda_private.h"
 #include "gloo/test/base_test.h"
 
-
 namespace gloo {
 namespace test {
 
@@ -29,8 +28,7 @@ class CudaFixture : public Fixture<T> {
     for (int i = 0; i < ptrs; i++) {
       CudaDeviceScope scope(i % cudaNumDevices());
       cudaSrcs.push_back(CudaMemory<T>(count));
-      cudaPtrs.push_back(
-        CudaDevicePointer<T>::create(*cudaSrcs.back(), count));
+      cudaPtrs.push_back(CudaDevicePointer<T>::create(*cudaSrcs.back(), count));
       cudaStreams.push_back(CudaStream(i));
     }
   }
@@ -42,11 +40,11 @@ class CudaFixture : public Fixture<T> {
     for (auto i = 0; i < cudaSrcs.size(); i++) {
       CudaDeviceScope scope(cudaStreams[i].getDeviceID());
       CUDA_CHECK(cudaMemcpyAsync(
-        *cudaSrcs[i],
-        this->srcs[i].get(),
-        cudaSrcs[i].bytes,
-        cudaMemcpyHostToDevice,
-        *cudaStreams[i]));
+          *cudaSrcs[i],
+          this->srcs[i].get(),
+          cudaSrcs[i].bytes,
+          cudaMemcpyHostToDevice,
+          *cudaStreams[i]));
     }
     // Synchronize every stream to ensure the memory copies have completed.
     for (auto i = 0; i < cudaSrcs.size(); i++) {
@@ -68,11 +66,11 @@ class CudaFixture : public Fixture<T> {
       // synchronization errors.
       cudaSleep(*cudaStreams[i], 100000);
       CUDA_CHECK(cudaMemcpyAsync(
-        *cudaSrcs[i],
-        this->srcs[i].get(),
-        cudaSrcs[i].bytes,
-        cudaMemcpyHostToDevice,
-        *cudaStreams[i]));
+          *cudaSrcs[i],
+          this->srcs[i].get(),
+          cudaSrcs[i].bytes,
+          cudaMemcpyHostToDevice,
+          *cudaStreams[i]));
     }
   }
 
@@ -95,11 +93,11 @@ class CudaFixture : public Fixture<T> {
   void copyToHost() {
     for (auto i = 0; i < cudaSrcs.size(); i++) {
       CUDA_CHECK(cudaMemcpyAsync(
-        this->srcs[i].get(),
-        *cudaSrcs[i],
-        cudaSrcs[i].bytes,
-        cudaMemcpyDeviceToHost,
-        *cudaStreams[i]));
+          this->srcs[i].get(),
+          *cudaSrcs[i],
+          cudaSrcs[i].bytes,
+          cudaMemcpyDeviceToHost,
+          *cudaStreams[i]));
     }
     synchronizeCudaStreams();
   }

--- a/gloo/test/cuda_broadcast_test.cc
+++ b/gloo/test/cuda_broadcast_test.cc
@@ -67,7 +67,7 @@ TEST_P(CudaBroadcastTest, Default) {
       for (auto rootPointerRank = 0; rootPointerRank < 1; rootPointerRank++) {
         fixture.assignValues();
         auto algorithm = fn(
-            context, ptrs, elementCount, rootProcessRank, rootPointerRank, {});
+            context, ptrs, dataSize, rootProcessRank, rootPointerRank, {});
         algorithm->run();
 
         // Verify result
@@ -91,7 +91,7 @@ TEST_P(CudaBroadcastTest, DefaultAsync) {
 
     // Run with varying root
     // TODO(PN): go up to contextSize
-    for (auto rootProcessRank = 0; rootProcessRank < numPointers; dataSize++) {
+    for (auto rootProcessRank = 0; rootProcessRank < numPointers; rootProcessRank++) {
       // TODO(PN): go up to pointerCount
       for (auto rootPointerRank = 0; rootPointerRank < 1; rootPointerRank++) {
         fixture.assignValuesAsync();

--- a/gloo/test/cuda_broadcast_test.cc
+++ b/gloo/test/cuda_broadcast_test.cc
@@ -66,8 +66,8 @@ TEST_P(CudaBroadcastTest, Default) {
       // TODO(PN): go up to pointerCount
       for (auto rootPointerRank = 0; rootPointerRank < 1; rootPointerRank++) {
         fixture.assignValues();
-        auto algorithm = fn(
-            context, ptrs, dataSize, rootProcessRank, rootPointerRank, {});
+        auto algorithm =
+            fn(context, ptrs, dataSize, rootProcessRank, rootPointerRank, {});
         algorithm->run();
 
         // Verify result
@@ -91,7 +91,8 @@ TEST_P(CudaBroadcastTest, DefaultAsync) {
 
     // Run with varying root
     // TODO(PN): go up to contextSize
-    for (auto rootProcessRank = 0; rootProcessRank < numPointers; rootProcessRank++) {
+    for (auto rootProcessRank = 0; rootProcessRank < numPointers;
+         rootProcessRank++) {
       // TODO(PN): go up to pointerCount
       for (auto rootPointerRank = 0; rootPointerRank < 1; rootPointerRank++) {
         fixture.assignValuesAsync();

--- a/gloo/test/gather_test.cc
+++ b/gloo/test/gather_test.cc
@@ -14,70 +14,62 @@ namespace test {
 namespace {
 
 // Test parameterization.
-using Param = std::tuple<int, size_t>;
+using Param = std::tuple<Transport, int, size_t>;
 
 // Test fixture.
 class GatherTest : public BaseTest,
-                   public ::testing::WithParamInterface<Param> {
-};
+                   public ::testing::WithParamInterface<Param> {};
 
 TEST_P(GatherTest, Default) {
-  auto contextSize = std::get<0>(GetParam());
-  auto dataSize = std::get<1>(GetParam());
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  const auto dataSize = std::get<2>(GetParam());
 
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
-      auto input = Fixture<uint64_t>(context, 1, dataSize);
-      auto output = Fixture<uint64_t>(context, 1, contextSize * dataSize);
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    auto input = Fixture<uint64_t>(context, 1, dataSize);
+    auto output = Fixture<uint64_t>(context, 1, contextSize * dataSize);
 
-      // Initialize fixture with globally unique values
-      input.assignValues();
+    // Initialize fixture with globally unique values
+    input.assignValues();
 
-      GatherOptions opts(context);
-      opts.setInput(input.getPointer(), dataSize);
+    GatherOptions opts(context);
+    opts.setInput(input.getPointer(), dataSize);
 
-      // Take turns being root
-      for (auto i = 0; i < context->size; i++) {
-        // Set output pointer only when root
-        if (i == context->rank) {
-          opts.setOutput(output.getPointer(), dataSize * contextSize);
-        }
+    // Take turns being root
+    for (auto i = 0; i < context->size; i++) {
+      // Set output pointer only when root
+      if (i == context->rank) {
+        opts.setOutput(output.getPointer(), dataSize * contextSize);
+      }
 
-        opts.setRoot(i);
-        gather(opts);
+      opts.setRoot(i);
+      gather(opts);
 
-        // Validate result if root
-        if (i == context->rank) {
-          const auto ptr = output.getPointer();
-          const auto stride = context->size;
-          for (auto j = 0; j < context->size; j++) {
-            for (auto k = 0; k < dataSize; k++) {
-              ASSERT_EQ(j + k * stride, ptr[k + j * dataSize])
+      // Validate result if root
+      if (i == context->rank) {
+        const auto ptr = output.getPointer();
+        const auto stride = context->size;
+        for (auto j = 0; j < context->size; j++) {
+          for (auto k = 0; k < dataSize; k++) {
+            ASSERT_EQ(j + k * stride, ptr[k + j * dataSize])
                 << "Mismatch at index " << (k + j * dataSize);
-            }
           }
         }
       }
-    });
-}
-
-std::vector<size_t> genMemorySizes() {
-  std::vector<size_t> v;
-  v.push_back(1);
-  v.push_back(10);
-  v.push_back(100);
-  v.push_back(1000);
-  return v;
+    }
+  });
 }
 
 INSTANTIATE_TEST_CASE_P(
     GatherDefault,
     GatherTest,
     ::testing::Combine(
+        ::testing::ValuesIn(kTransportsForFunctionAlgorithms),
         ::testing::Values(1, 2, 4, 7),
-        ::testing::ValuesIn(genMemorySizes())));
+        ::testing::Values(4, 100, 1000, 10000)));
 
 TEST_F(GatherTest, TestTimeout) {
-  spawn(2, [&](std::shared_ptr<Context> context) {
+  spawn(Transport::TCP, 2, [&](std::shared_ptr<Context> context) {
     Fixture<uint64_t> input(context, 1, 1);
     Fixture<uint64_t> output(context, 1, context->size);
     GatherOptions opts(context);

--- a/gloo/test/main.cc
+++ b/gloo/test/main.cc
@@ -16,7 +16,7 @@ struct Initializer {
   }
 };
 Initializer initializer;
-}
+} // namespace
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/gloo/test/memory_test.cc
+++ b/gloo/test/memory_test.cc
@@ -28,7 +28,7 @@ size_t readResidentSetSize() {
 class MemoryTest : public BaseTest {};
 
 TEST_F(MemoryTest, ManySlotsNoLeaks) {
-  spawn(2, [&](std::shared_ptr<Context> context) {
+  spawn(Transport::TCP, 2, [&](std::shared_ptr<Context> context) {
     size_t tmp0;
     size_t tmp1;
     auto buf0 = context->createUnboundBuffer(&tmp0, sizeof(tmp0));

--- a/gloo/test/multiproc_test.cc
+++ b/gloo/test/multiproc_test.cc
@@ -12,8 +12,8 @@
 #include <ftw.h>
 
 #include <array>
-#include <string>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include "gloo/common/error.h"
@@ -28,8 +28,7 @@ static std::string createTempDirectory() {
 }
 
 static int removeTree(const std::string& root) {
-  static auto fn = [](
-      const char* path, const struct stat*, int, struct FTW*) {
+  static auto fn = [](const char* path, const struct stat*, int, struct FTW*) {
     return remove(path);
   };
   return nftw(root.c_str(), fn, 20, FTW_DEPTH);
@@ -86,8 +85,7 @@ void MultiProcTest::signalProcess(int rank, int signal) {
   ASSERT_EQ(0, result);
 }
 
-void MultiProcTest::wait()
-{
+void MultiProcTest::wait() {
   for (auto i = 0; i < workers_.size(); i++) {
     waitProcess(i);
   }

--- a/gloo/test/multiproc_test.h
+++ b/gloo/test/multiproc_test.h
@@ -40,7 +40,7 @@ class MultiProcTest : public ::testing::Test {
     return workerResults_[rank];
   }
 
-  void spawn(int size, std::function<void(std::shared_ptr<Context>)> fn) ;
+  void spawn(int size, std::function<void(std::shared_ptr<Context>)> fn);
 
  private:
   int runWorker(
@@ -53,7 +53,6 @@ class MultiProcTest : public ::testing::Test {
   sem_t* semaphore_;
   std::vector<pid_t> workers_;
   std::vector<int> workerResults_;
-
 };
 
 class MultiProcWorker {
@@ -75,8 +74,7 @@ class MultiProcWorker {
       int size,
       int rank,
       std::function<void(std::shared_ptr<Context>)> fn) {
-    auto context =
-      std::make_shared<::gloo::rendezvous::Context>(rank, size);
+    auto context = std::make_shared<::gloo::rendezvous::Context>(rank, size);
     auto device = ::gloo::transport::tcp::CreateDevice("localhost");
     context->setTimeout(std::chrono::milliseconds(kMultiProcTimeout));
     context->connectFullMesh(*store_, device);

--- a/gloo/test/reduce_test.cc
+++ b/gloo/test/reduce_test.cc
@@ -79,16 +79,6 @@ TEST_P(ReduceTest, Default) {
   });
 }
 
-std::vector<size_t> genMemorySizes() {
-  std::vector<size_t> v;
-  v.push_back(1);
-  v.push_back(10);
-  v.push_back(100);
-  v.push_back(1000);
-  v.push_back(10000);
-  return v;
-}
-
 INSTANTIATE_TEST_CASE_P(
     ReduceDefault,
     ReduceTest,

--- a/gloo/test/scatter_test.cc
+++ b/gloo/test/scatter_test.cc
@@ -15,17 +15,18 @@ namespace test {
 namespace {
 
 // Test parameterization.
-using Param = std::tuple<int, size_t>;
+using Param = std::tuple<Transport, int, size_t>;
 
 // Test fixture.
 class ScatterTest : public BaseTest,
                     public ::testing::WithParamInterface<Param> {};
 
 TEST_P(ScatterTest, Default) {
-  auto contextSize = std::get<0>(GetParam());
-  auto dataSize = std::get<1>(GetParam());
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  const auto dataSize = std::get<2>(GetParam());
 
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
     auto input = Fixture<uint64_t>(context, contextSize, dataSize);
     auto output = Fixture<uint64_t>(context, 1, dataSize);
 
@@ -67,11 +68,12 @@ INSTANTIATE_TEST_CASE_P(
     ScatterDefault,
     ScatterTest,
     ::testing::Combine(
+        ::testing::ValuesIn(kTransportsForFunctionAlgorithms),
         ::testing::Values(1, 2, 4, 7),
-        ::testing::ValuesIn(genMemorySizes())));
+        ::testing::Values(1, 10, 100)));
 
 TEST_F(ScatterTest, TestTimeout) {
-  spawn(2, [&](std::shared_ptr<Context> context) {
+  spawn(Transport::TCP, 2, [&](std::shared_ptr<Context> context) {
     Fixture<uint64_t> input(context, context->size, 1);
     Fixture<uint64_t> output(context, 1, 1);
     ScatterOptions opts(context);

--- a/gloo/test/send_recv_test.cc
+++ b/gloo/test/send_recv_test.cc
@@ -8,8 +8,8 @@
 
 #include "gloo/test/base_test.h"
 
-#include <unordered_set>
 #include <array>
+#include <unordered_set>
 
 #include "gloo/transport/tcp/unbound_buffer.h"
 
@@ -17,308 +17,318 @@ namespace gloo {
 namespace test {
 namespace {
 
-// Test parameterization (context size, buffer size).
-using Param = std::tuple<int, int>;
+// Test parameterization (transport, context size, buffer size).
+using Param = std::tuple<Transport, int, int>;
 
 // Test fixture.
 class SendRecvTest : public BaseTest,
                      public ::testing::WithParamInterface<Param> {};
 
 TEST_P(SendRecvTest, AllToAll) {
-  auto contextSize = std::get<0>(GetParam());
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
-      using buffer_ptr = std::unique_ptr<::gloo::transport::UnboundBuffer>;
-      std::vector<int> input(contextSize);
-      std::vector<int> output(contextSize);
-      std::vector<buffer_ptr> inputBuffers(contextSize);
-      std::vector<buffer_ptr> outputBuffers(contextSize);
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
 
-      // Initialize
-      for (auto i = 0; i < context->size; i++) {
-        input[i] = context->rank;
-        output[i] = -1;
-        inputBuffers[i] =
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    using buffer_ptr = std::unique_ptr<::gloo::transport::UnboundBuffer>;
+    std::vector<int> input(contextSize);
+    std::vector<int> output(contextSize);
+    std::vector<buffer_ptr> inputBuffers(contextSize);
+    std::vector<buffer_ptr> outputBuffers(contextSize);
+
+    // Initialize
+    for (auto i = 0; i < context->size; i++) {
+      input[i] = context->rank;
+      output[i] = -1;
+      inputBuffers[i] =
           context->createUnboundBuffer(&input[i], sizeof(input[i]));
-        outputBuffers[i] =
+      outputBuffers[i] =
           context->createUnboundBuffer(&output[i], sizeof(output[i]));
-      }
+    }
 
-      // Send a message with the local rank to every other rank
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        inputBuffers[i]->send(i, context->rank);
+    // Send a message with the local rank to every other rank
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
       }
+      inputBuffers[i]->send(i, context->rank);
+    }
 
-      // Receive message from every other rank
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        outputBuffers[i]->recv(i, i);
+    // Receive message from every other rank
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
       }
+      outputBuffers[i]->recv(i, i);
+    }
 
-      // Wait for send and recv to complete
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        inputBuffers[i]->waitSend();
-        outputBuffers[i]->waitRecv();
+    // Wait for send and recv to complete
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
       }
+      inputBuffers[i]->waitSend();
+      outputBuffers[i]->waitRecv();
+    }
 
-      // Verify output
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        ASSERT_EQ(i, output[i]) << "Mismatch at index " << i;
+    // Verify output
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
       }
-    });
+      ASSERT_EQ(i, output[i]) << "Mismatch at index " << i;
+    }
+  });
 }
 
 TEST_P(SendRecvTest, AllToAllOffset) {
-  auto contextSize = std::get<0>(GetParam());
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
-      auto elementSize = sizeof(int);
-      std::vector<int> input(contextSize);
-      std::vector<int> output(contextSize);
-      auto inputBuffer = context->createUnboundBuffer(
-          input.data(), input.size() * elementSize);
-      auto outputBuffer = context->createUnboundBuffer(
-          output.data(), output.size() * elementSize);
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
 
-      // Initialize
-      for (auto i = 0; i < context->size; i++) {
-        input[i] = i;
-        output[i] = -1;
-      }
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    auto elementSize = sizeof(int);
+    std::vector<int> input(contextSize);
+    std::vector<int> output(contextSize);
+    auto inputBuffer =
+        context->createUnboundBuffer(input.data(), input.size() * elementSize);
+    auto outputBuffer = context->createUnboundBuffer(
+        output.data(), output.size() * elementSize);
 
-      // Send a message with the local rank to every other rank
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        inputBuffer->send(i, 0, context->rank * elementSize, elementSize);
-      }
+    // Initialize
+    for (auto i = 0; i < context->size; i++) {
+      input[i] = i;
+      output[i] = -1;
+    }
 
-      // Receive message from every other rank
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        outputBuffer->recv(i, 0, i * elementSize, elementSize);
+    // Send a message with the local rank to every other rank
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
       }
+      inputBuffer->send(i, 0, context->rank * elementSize, elementSize);
+    }
 
-      // Wait for send and recv to complete
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        inputBuffer->waitSend();
-        outputBuffer->waitRecv();
+    // Receive message from every other rank
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
       }
+      outputBuffer->recv(i, 0, i * elementSize, elementSize);
+    }
 
-      // Verify output
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        ASSERT_EQ(i, output[i]) << "Mismatch at index " << i;
+    // Wait for send and recv to complete
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
       }
-    });
+      inputBuffer->waitSend();
+      outputBuffer->waitRecv();
+    }
+
+    // Verify output
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
+      }
+      ASSERT_EQ(i, output[i]) << "Mismatch at index " << i;
+    }
+  });
 }
 
 TEST_P(SendRecvTest, AllToAllEmptyThenNonEmpty) {
-  auto contextSize = std::get<0>(GetParam());
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
-      auto elementSize = sizeof(int);
-      std::vector<int> input(contextSize);
-      std::vector<int> output(contextSize);
-      using buffer_ptr = std::unique_ptr<::gloo::transport::UnboundBuffer>;
-      std::vector<buffer_ptr> emptyInputBuffers(contextSize);
-      std::vector<buffer_ptr> emptyOutputBuffers(contextSize);
-      std::vector<buffer_ptr> nonEmptyInputBuffers(contextSize);
-      std::vector<buffer_ptr> nonEmptyOutputBuffers(contextSize);
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
 
-      // Initialize
-      for (auto i = 0; i < context->size; i++) {
-        input[i] = context->rank;
-        output[i] = -1;
-        emptyInputBuffers[i] =
-          context->createUnboundBuffer(nullptr, 0);
-        emptyOutputBuffers[i] =
-          context->createUnboundBuffer(nullptr, 0);
-        nonEmptyInputBuffers[i] =
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    auto elementSize = sizeof(int);
+    std::vector<int> input(contextSize);
+    std::vector<int> output(contextSize);
+    using buffer_ptr = std::unique_ptr<::gloo::transport::UnboundBuffer>;
+    std::vector<buffer_ptr> emptyInputBuffers(contextSize);
+    std::vector<buffer_ptr> emptyOutputBuffers(contextSize);
+    std::vector<buffer_ptr> nonEmptyInputBuffers(contextSize);
+    std::vector<buffer_ptr> nonEmptyOutputBuffers(contextSize);
+
+    // Initialize
+    for (auto i = 0; i < context->size; i++) {
+      input[i] = context->rank;
+      output[i] = -1;
+      emptyInputBuffers[i] = context->createUnboundBuffer(nullptr, 0);
+      emptyOutputBuffers[i] = context->createUnboundBuffer(nullptr, 0);
+      nonEmptyInputBuffers[i] =
           context->createUnboundBuffer(&input[i], elementSize);
-        nonEmptyOutputBuffers[i] =
+      nonEmptyOutputBuffers[i] =
           context->createUnboundBuffer(&output[i], elementSize);
-      }
+    }
 
-      // Kick off all sends and receives
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        emptyOutputBuffers[i]->recv(i, i);
-        emptyInputBuffers[i]->send(i, context->rank);
-        nonEmptyOutputBuffers[i]->recv(i, i);
-        nonEmptyInputBuffers[i]->send(i, context->rank);
+    // Kick off all sends and receives
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
       }
+      emptyOutputBuffers[i]->recv(i, i);
+      emptyInputBuffers[i]->send(i, context->rank);
+      nonEmptyOutputBuffers[i]->recv(i, i);
+      nonEmptyInputBuffers[i]->send(i, context->rank);
+    }
 
-      // Wait for send and recv to complete
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        emptyInputBuffers[i]->waitSend();
-        emptyOutputBuffers[i]->waitRecv();
-        nonEmptyInputBuffers[i]->waitSend();
-        nonEmptyOutputBuffers[i]->waitRecv();
+    // Wait for send and recv to complete
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
       }
+      emptyInputBuffers[i]->waitSend();
+      emptyOutputBuffers[i]->waitRecv();
+      nonEmptyInputBuffers[i]->waitSend();
+      nonEmptyOutputBuffers[i]->waitRecv();
+    }
 
-      // Verify output
-      for (auto i = 0; i < context->size; i++) {
-        if (i == context->rank) {
-          continue;
-        }
-        ASSERT_EQ(i, output[i]) << "Mismatch at index " << i;
+    // Verify output
+    for (auto i = 0; i < context->size; i++) {
+      if (i == context->rank) {
+        continue;
       }
-    });
+      ASSERT_EQ(i, output[i]) << "Mismatch at index " << i;
+    }
+  });
 }
 
 TEST_P(SendRecvTest, RecvFromAny) {
-  auto contextSize = std::get<0>(GetParam());
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
-      constexpr uint64_t slot = 0x1337;
-      if (context->rank == 0) {
-        std::unordered_set<int> outputData;
-        std::unordered_set<int> outputRanks;
-        int tmp;
-        auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
 
-        // Compile vector of ranks to receive from
-        std::vector<int> ranks;
-        for (auto i = 1; i < context->size; i++) {
-          ranks.push_back(i);
-        }
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    constexpr uint64_t slot = 0x1337;
+    if (context->rank == 0) {
+      std::unordered_set<int> outputData;
+      std::unordered_set<int> outputRanks;
+      int tmp;
+      auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
 
-        // Receive from N-1 peers
-        for (auto i = 1; i < context->size; i++) {
-          int srcRank = -1;
-          buf->recv(ranks, slot);
-          buf->waitRecv(&srcRank);
-          outputData.insert(tmp);
-          outputRanks.insert(srcRank);
-        }
-
-        // Verify result
-        for (auto i = 1; i < context->size; i++) {
-          ASSERT_EQ(1, outputData.count(i)) << "Missing output " << i;
-          ASSERT_EQ(1, outputRanks.count(i)) << "Missing rank " << i;
-        }
-      } else {
-        // Send to rank 0
-        int tmp = context->rank;
-        auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
-        buf->send(0, slot);
-        buf->waitSend();
+      // Compile vector of ranks to receive from
+      std::vector<int> ranks;
+      for (auto i = 1; i < context->size; i++) {
+        ranks.push_back(i);
       }
-    });
+
+      // Receive from N-1 peers
+      for (auto i = 1; i < context->size; i++) {
+        int srcRank = -1;
+        buf->recv(ranks, slot);
+        buf->waitRecv(&srcRank);
+        outputData.insert(tmp);
+        outputRanks.insert(srcRank);
+      }
+
+      // Verify result
+      for (auto i = 1; i < context->size; i++) {
+        ASSERT_EQ(1, outputData.count(i)) << "Missing output " << i;
+        ASSERT_EQ(1, outputRanks.count(i)) << "Missing rank " << i;
+      }
+    } else {
+      // Send to rank 0
+      int tmp = context->rank;
+      auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
+      buf->send(0, slot);
+      buf->waitSend();
+    }
+  });
 }
 
 TEST_P(SendRecvTest, RecvFromAnyOffset) {
-  auto contextSize = std::get<0>(GetParam());
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
-      auto elementSize = sizeof(int);
-      constexpr uint64_t slot = 0x1337;
-      if (context->rank == 0) {
-        std::unordered_set<int> outputData;
-        std::unordered_set<int> outputRanks;
-        std::array<int, 2> tmp;
-        auto buf =
-            context->createUnboundBuffer(tmp.data(), tmp.size() * elementSize);
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
 
-        // Compile vector of ranks to receive from
-        std::vector<int> ranks;
-        for (auto i = 1; i < context->size; i++) {
-          ranks.push_back(i);
-        }
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    auto elementSize = sizeof(int);
+    constexpr uint64_t slot = 0x1337;
+    if (context->rank == 0) {
+      std::unordered_set<int> outputData;
+      std::unordered_set<int> outputRanks;
+      std::array<int, 2> tmp;
+      auto buf =
+          context->createUnboundBuffer(tmp.data(), tmp.size() * elementSize);
 
-        // Receive from N-1 peers
-        for (auto i = 1; i < context->size; i++) {
-          int srcRank = -1;
-          buf->recv(ranks, slot, (i % tmp.size()) * elementSize, elementSize);
-          buf->waitRecv(&srcRank);
-          outputData.insert(tmp[i % tmp.size()]);
-          outputRanks.insert(srcRank);
-        }
-
-        // Verify result
-        for (auto i = 1; i < context->size; i++) {
-          ASSERT_EQ(1, outputData.count(i)) << "Missing output " << i;
-          ASSERT_EQ(1, outputRanks.count(i)) << "Missing rank " << i;
-        }
-      } else {
-        // Send to rank 0
-        int tmp = context->rank;
-        auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
-        buf->send(0, slot);
-        buf->waitSend();
+      // Compile vector of ranks to receive from
+      std::vector<int> ranks;
+      for (auto i = 1; i < context->size; i++) {
+        ranks.push_back(i);
       }
-    });
+
+      // Receive from N-1 peers
+      for (auto i = 1; i < context->size; i++) {
+        int srcRank = -1;
+        buf->recv(ranks, slot, (i % tmp.size()) * elementSize, elementSize);
+        buf->waitRecv(&srcRank);
+        outputData.insert(tmp[i % tmp.size()]);
+        outputRanks.insert(srcRank);
+      }
+
+      // Verify result
+      for (auto i = 1; i < context->size; i++) {
+        ASSERT_EQ(1, outputData.count(i)) << "Missing output " << i;
+        ASSERT_EQ(1, outputRanks.count(i)) << "Missing rank " << i;
+      }
+    } else {
+      // Send to rank 0
+      int tmp = context->rank;
+      auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
+      buf->send(0, slot);
+      buf->waitSend();
+    }
+  });
 }
 
 TEST_P(SendRecvTest, RecvFromAnyPipeline) {
-  auto contextSize = std::get<0>(GetParam());
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
-      constexpr uint64_t slot = 0x1337;
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
 
-      if (context->rank == 0) {
-        std::vector<int> output;
-        std::array<int, 2> tmp;
-        auto buf0 = context->createUnboundBuffer(&tmp[0], sizeof(tmp[0]));
-        auto buf1 = context->createUnboundBuffer(&tmp[1], sizeof(tmp[1]));
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    constexpr uint64_t slot = 0x1337;
 
-        // Compile vector of ranks to receive from
-        std::vector<int> ranks;
-        for (auto i = 0; i < context->size; i++) {
-          if (i == context->rank) {
-            continue;
-          }
-          ranks.push_back(i);
+    if (context->rank == 0) {
+      std::vector<int> output;
+      std::array<int, 2> tmp;
+      auto buf0 = context->createUnboundBuffer(&tmp[0], sizeof(tmp[0]));
+      auto buf1 = context->createUnboundBuffer(&tmp[1], sizeof(tmp[1]));
+
+      // Compile vector of ranks to receive from
+      std::vector<int> ranks;
+      for (auto i = 0; i < context->size; i++) {
+        if (i == context->rank) {
+          continue;
         }
-
-        // Receive twice per peer
-        for (auto i = 0; i < context->size - 1; i++) {
-          buf0->recv(ranks, slot);
-          buf1->recv(ranks, slot);
-          buf0->waitRecv();
-          buf1->waitRecv();
-          output.push_back(tmp[0]);
-          output.push_back(tmp[1]);
-        }
-
-        // Verify output
-        std::sort(output.begin(), output.end());
-        for (auto i = 1; i < context->size; i++) {
-          ASSERT_EQ(i, output[(i-1) * 2 + 0]) << "Mismatch at " << i;
-          ASSERT_EQ(i, output[(i-1) * 2 + 1]) << "Mismatch at " << i;
-        }
-      } else {
-        // Send twice to rank 0 on the same slot
-        std::array<int, 2> tmp;
-        tmp[0] = context->rank;
-        tmp[1] = context->rank;
-        auto buf0 = context->createUnboundBuffer(&tmp[0], sizeof(tmp[0]));
-        auto buf1 = context->createUnboundBuffer(&tmp[1], sizeof(tmp[1]));
-        buf0->send(0, slot);
-        buf1->send(0, slot);
-        buf0->waitSend();
-        buf1->waitSend();
+        ranks.push_back(i);
       }
-    });
+
+      // Receive twice per peer
+      for (auto i = 0; i < context->size - 1; i++) {
+        buf0->recv(ranks, slot);
+        buf1->recv(ranks, slot);
+        buf0->waitRecv();
+        buf1->waitRecv();
+        output.push_back(tmp[0]);
+        output.push_back(tmp[1]);
+      }
+
+      // Verify output
+      std::sort(output.begin(), output.end());
+      for (auto i = 1; i < context->size; i++) {
+        ASSERT_EQ(i, output[(i - 1) * 2 + 0]) << "Mismatch at " << i;
+        ASSERT_EQ(i, output[(i - 1) * 2 + 1]) << "Mismatch at " << i;
+      }
+    } else {
+      // Send twice to rank 0 on the same slot
+      std::array<int, 2> tmp;
+      tmp[0] = context->rank;
+      tmp[1] = context->rank;
+      auto buf0 = context->createUnboundBuffer(&tmp[0], sizeof(tmp[0]));
+      auto buf1 = context->createUnboundBuffer(&tmp[1], sizeof(tmp[1]));
+      buf0->send(0, slot);
+      buf1->send(0, slot);
+      buf0->waitSend();
+      buf1->waitSend();
+    }
+  });
 }
 
 // This test stresses the pattern that is commonly used for some sort
@@ -327,58 +337,62 @@ TEST_P(SendRecvTest, RecvFromAnyPipeline) {
 // receive the message size and rank of a client, followed by an
 // immediate recv from that rank to get the actual message.
 TEST_P(SendRecvTest, RecvFromAnyRPC) {
-  auto contextSize = std::get<0>(GetParam());
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
-      constexpr uint64_t slot = 0x1337;
-      constexpr auto niters = 10;
-      size_t tmp0;
-      size_t tmp1;
-      auto buf0 = context->createUnboundBuffer(&tmp0, sizeof(tmp0));
-      auto buf1 = context->createUnboundBuffer(&tmp1, sizeof(tmp1));
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
 
-      if (context->rank == 0) {
-        // Keep number of recvs per rank
-        std::unordered_map<int, int> counts;
-        // Compile vector of ranks to receive from
-        std::vector<int> allRanks;
-        for (auto i = 0; i < context->size; i++) {
-          if (i == context->rank) {
-            continue;
-          }
-          allRanks.push_back(i);
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    constexpr uint64_t slot = 0x1337;
+    constexpr auto niters = 10;
+    size_t tmp0;
+    size_t tmp1;
+    auto buf0 = context->createUnboundBuffer(&tmp0, sizeof(tmp0));
+    auto buf1 = context->createUnboundBuffer(&tmp1, sizeof(tmp1));
+
+    if (context->rank == 0) {
+      // Keep number of recvs per rank
+      std::unordered_map<int, int> counts;
+      // Compile vector of ranks to receive from
+      std::vector<int> allRanks;
+      for (auto i = 0; i < context->size; i++) {
+        if (i == context->rank) {
+          continue;
         }
-        // Receive twice from every peer, niters times
-        for (auto i = 0; i < (niters * (context->size - 1)); i++) {
-          int rank;
-          // Receive from any peer first
-          buf0->recv(allRanks, slot);
-          buf0->waitRecv(&rank);
-          counts[rank]++;
-          // Then receive from the same peer again
-          buf1->recv(rank, slot);
-          buf1->waitRecv();
-        }
-        // Verify result
-        for (auto i = 0; i < context->size; i++) {
-          if (i == context->rank) {
-            continue;
-          }
-          ASSERT_EQ(niters, counts[i]) << "recv mismatch for rank " << i;
-        }
-      } else {
-        for (auto i = 0; i < niters; i++) {
-          buf0->send(0, slot);
-          buf0->waitSend();
-          buf1->send(0, slot);
-          buf1->waitSend();
-        }
+        allRanks.push_back(i);
       }
-    });
+      // Receive twice from every peer, niters times
+      for (auto i = 0; i < (niters * (context->size - 1)); i++) {
+        int rank;
+        // Receive from any peer first
+        buf0->recv(allRanks, slot);
+        buf0->waitRecv(&rank);
+        counts[rank]++;
+        // Then receive from the same peer again
+        buf1->recv(rank, slot);
+        buf1->waitRecv();
+      }
+      // Verify result
+      for (auto i = 0; i < context->size; i++) {
+        if (i == context->rank) {
+          continue;
+        }
+        ASSERT_EQ(niters, counts[i]) << "recv mismatch for rank " << i;
+      }
+    } else {
+      for (auto i = 0; i < niters; i++) {
+        buf0->send(0, slot);
+        buf0->waitSend();
+        buf1->send(0, slot);
+        buf1->waitSend();
+      }
+    }
+  });
 }
 
 TEST_P(SendRecvTest, RecvFromAnyRPCEmptyThenNonEmpty) {
-  auto contextSize = std::get<0>(GetParam());
-  spawn(contextSize, [&](std::shared_ptr<Context> context) {
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
     constexpr uint64_t slot = 0x1337;
     constexpr auto niters = 10;
     size_t tmp0;
@@ -426,9 +440,9 @@ INSTANTIATE_TEST_CASE_P(
     SendRecvDefault,
     SendRecvTest,
     ::testing::Combine(
+        ::testing::Values(Transport::TCP),
         ::testing::Values(2, 3, 4, 5, 6, 7, 8),
         ::testing::Values(1)));
-
 
 } // namespace
 } // namespace test

--- a/gloo/test/transport_test.cc
+++ b/gloo/test/transport_test.cc
@@ -16,11 +16,7 @@ namespace gloo {
 namespace test {
 namespace {
 
-enum IoMode {
-  Async,
-  Blocking,
-  Polling
-};
+enum IoMode { Async, Blocking, Polling };
 
 // Test parameterization.
 using Param = std::tuple<int, int, int, IoMode>;
@@ -30,7 +26,7 @@ class TransportMultiProcTest : public MultiProcTest,
                                public ::testing::WithParamInterface<Param> {};
 
 static void setMode(std::unique_ptr<transport::Pair>& pair, IoMode mode) {
-  switch(mode) {
+  switch (mode) {
     case IoMode::Async:
       // Async is default mode
       break;
@@ -52,32 +48,32 @@ TEST_P(TransportMultiProcTest, IoErrors) {
   const auto mode = std::get<3>(GetParam());
 
   spawnAsync(processCount, [&](std::shared_ptr<Context> context) {
-      std::vector<float> data;
-      data.resize(elementCount);
-      std::unique_ptr<transport::Buffer> sendBuffer;
-      std::unique_ptr<transport::Buffer> recvBuffer;
+    std::vector<float> data;
+    data.resize(elementCount);
+    std::unique_ptr<transport::Buffer> sendBuffer;
+    std::unique_ptr<transport::Buffer> recvBuffer;
 
-      const auto& leftRank = (processCount + context->rank - 1) % processCount;
-      auto& left = context->getPair(leftRank);
-      setMode(left, mode);
-      recvBuffer = left->createRecvBuffer(
-      0, data.data(), data.size() * sizeof(float));
+    const auto& leftRank = (processCount + context->rank - 1) % processCount;
+    auto& left = context->getPair(leftRank);
+    setMode(left, mode);
+    recvBuffer =
+        left->createRecvBuffer(0, data.data(), data.size() * sizeof(float));
 
-      const auto& rightRank = (context->rank + 1) % processCount;
-      auto& right = context->getPair(rightRank);
-      setMode(right, mode);
-      sendBuffer = right->createSendBuffer(
-      0, data.data(), data.size() * sizeof(float));
+    const auto& rightRank = (context->rank + 1) % processCount;
+    auto& right = context->getPair(rightRank);
+    setMode(right, mode);
+    sendBuffer =
+        right->createSendBuffer(0, data.data(), data.size() * sizeof(float));
 
-      while (true) {
-        // Send value to the remote buffer
-        sendBuffer->send(0, sizeof(float));
-        sendBuffer->waitSend();
+    while (true) {
+      // Send value to the remote buffer
+      sendBuffer->send(0, sizeof(float));
+      sendBuffer->waitSend();
 
-        // Wait for receive
-        recvBuffer->waitRecv();
-      }
-    });
+      // Wait for receive
+      recvBuffer->waitRecv();
+    }
+  });
   if (sleepMs > 0) {
     // The test is specifically delaying before killing dependent processes.
     // The absolute time does not need to be deterministic.
@@ -91,7 +87,7 @@ TEST_P(TransportMultiProcTest, IoErrors) {
   signalProcess(0, SIGKILL);
   wait();
   const auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(
-    std::chrono::high_resolution_clock::now() - start);
+      std::chrono::high_resolution_clock::now() - start);
   ASSERT_LT(delta.count(), kMultiProcTimeout.count() / 2);
 
   for (auto i = 0; i < processCount; i++) {
@@ -109,30 +105,30 @@ TEST_P(TransportMultiProcTest, IoTimeouts) {
   const auto sleepMs = std::get<2>(GetParam());
 
   spawnAsync(processCount, [&](std::shared_ptr<Context> context) {
-      std::vector<float> data;
-      data.resize(elementCount);
-      std::unique_ptr<transport::Buffer> sendBuffer;
-      std::unique_ptr<transport::Buffer> recvBuffer;
+    std::vector<float> data;
+    data.resize(elementCount);
+    std::unique_ptr<transport::Buffer> sendBuffer;
+    std::unique_ptr<transport::Buffer> recvBuffer;
 
-      const auto& leftRank = (processCount + context->rank - 1) % processCount;
-      auto& left = context->getPair(leftRank);
-      recvBuffer = left->createRecvBuffer(
-      0, data.data(), data.size() * sizeof(float));
+    const auto& leftRank = (processCount + context->rank - 1) % processCount;
+    auto& left = context->getPair(leftRank);
+    recvBuffer =
+        left->createRecvBuffer(0, data.data(), data.size() * sizeof(float));
 
-      const auto& rightRank = (context->rank + 1) % processCount;
-      auto& right = context->getPair(rightRank);
-      sendBuffer = right->createSendBuffer(
-      0, data.data(), data.size() * sizeof(float));
+    const auto& rightRank = (context->rank + 1) % processCount;
+    auto& right = context->getPair(rightRank);
+    sendBuffer =
+        right->createSendBuffer(0, data.data(), data.size() * sizeof(float));
 
-      while (true) {
-        // Send value to the remote buffer
-        sendBuffer->send(0, sizeof(float));
-        sendBuffer->waitSend();
+    while (true) {
+      // Send value to the remote buffer
+      sendBuffer->send(0, sizeof(float));
+      sendBuffer->waitSend();
 
-        // Wait for receive
-        recvBuffer->waitRecv();
-      }
-    });
+      // Wait for receive
+      recvBuffer->waitRecv();
+    }
+  });
   if (sleepMs > 0) {
     // The test is specifically delaying before killing dependent processes.
     // The absolute time does not need to be deterministic.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #212 Create libuv transport
* **#208 Refactor algorithm tests to take transport parameter**

This is required to run the same algorithm tests against multiple
transports. The test suite is comprised of both class algorithms and
function algorithms. The former require fixed buffers, which are only
supported on the tcp backend (and will be phased out). The latter
require the unbound buffers, which are supported on both the tcp and
uv (not yet merged) transports. This means we can't set the transport
globally and forget about it, since it depends on the test whether or
not it works with the selected transport.

Instead, by parameterizing the tests we allow for multiple transports
to be tested in the same test run. If a transport is not
available (e.g. not compiled) then those tests can be skipped.

Side notes:

* There are a series of small modifications included here as well,
  including more consistent variable naming, and a more consistent
  usage of test parameterization generator functions.
* Because this commit touches many lines anyway, I also ran
  clang-format on all files under `gloo/test` to make the style
  consistent.

Differential Revision: [D17072673](https://our.internmc.facebook.com/intern/diff/D17072673)