### PR TITLE
Make libuv detection code more robust

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -43,11 +43,19 @@ if(USE_LIBUV)
     #
   else()
     include(FindPkgConfig)
-    pkg_search_module(libuv REQUIRED libuv>=1.29)
+    pkg_search_module(libuv REQUIRED libuv>=1.26)
+    find_file(
+      libuv_LIBRARY
+      NAMES libuv.a libuv_a.a
+      PATHS ${libuv_LIBDIR}
+      NO_DEFAULT_PATH)
+    if(NOT EXISTS ${libuv_LIBRARY})
+      message(FATAL "Unable to find static libuv library in " ${libuv_LIBDIR})
+    endif()
     add_library(uv_a INTERFACE IMPORTED)
     set_target_properties(uv_a PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES ${libuv_INCLUDE_DIRS}
-      INTERFACE_LINK_LIBRARIES ${libuv_LIBDIR}/libuv_a.a
+      INTERFACE_LINK_LIBRARIES ${libuv_LIBRARY}
       )
   endif()
 endif()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #216 Fix compilation of CUDA code on macOS
* #215 Use uv_os_gethostname instead of gethostname
* #214 Fix mismatch between declaration and definition
* **#213 Make libuv detection code more robust**

The anaconda package for libuv uses version 1.26. There are no
features introduced since then that we rely on, so we can use that as
minimum version.

The static library in the anaconda package is named `libuv.a`. When
libuv is compiled and installed from source it produces a static
library named `libuv_a.a`. We use CMake's `find_file` to figure out
which is used.

Differential Revision: [D17153544](https://our.internmc.facebook.com/intern/diff/D17153544)