### PR TITLE
Fix mismatch between declaration and definition

### DIFF
--- a/gloo/transport/uv/context.cc
+++ b/gloo/transport/uv/context.cc
@@ -20,7 +20,7 @@ namespace uv {
 
 using count_t = PendingOpCount::count_t;
 
-ContextMutator::ContextMutator(Context& context, size_t slot, size_t rank)
+ContextMutator::ContextMutator(Context& context, uint64_t slot, uint64_t rank)
     : lock_(context.m_),
       context_(context),
       slot_(slot),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #216 Fix compilation of CUDA code on macOS
* #215 Use uv_os_gethostname instead of gethostname
* **#214 Fix mismatch between declaration and definition**
* #213 Make libuv detection code more robust

The mismatch here is between `size_t` and `uint64_t`. This wasn't a
problem before because we only ran Linux builds.

Differential Revision: [D17153543](https://our.internmc.facebook.com/intern/diff/D17153543)