### PR TITLE
Use uv_os_gethostname instead of gethostname

### DIFF
--- a/gloo/transport/uv/device.cc
+++ b/gloo/transport/uv/device.cc
@@ -8,10 +8,13 @@
 
 #include <gloo/transport/uv/device.h>
 
+#include <array>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <sstream>
+
+#include <uv.h>
 
 #include <gloo/common/error.h>
 #include <gloo/common/linux.h>
@@ -140,10 +143,11 @@ std::shared_ptr<transport::Device> CreateDevice(struct attr attr) {
     // Initialize attributes using hostname/IP address
     // If not already specified, use this machine's hostname
     if (attr.hostname.size() == 0) {
-      std::array<char, HOST_NAME_MAX> hostname;
-      auto rv = gethostname(hostname.data(), hostname.size());
+      std::array<char, UV_MAXHOSTNAMESIZE> hostname;
+      size_t size = hostname.size();
+      auto rv = uv_os_gethostname(hostname.data(), &size);
       GLOO_ENFORCE_EQ(rv, 0);
-      attr.hostname = hostname.data();
+      attr.hostname = std::string(hostname.data(), size);
     }
     lookupAddrForHostname(attr);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #216 Fix compilation of CUDA code on macOS
* **#215 Use uv_os_gethostname instead of gethostname**
* #214 Fix mismatch between declaration and definition
* #213 Make libuv detection code more robust

On macOS the HOST_NAME_MAX constant is not available. Instead, the
equivalent value is only available through a sysconf property.

Note: UV_MAXHOSTNAMESIZE is available since libuv 1.26.0.

Differential Revision: [D17153542](https://our.internmc.facebook.com/intern/diff/D17153542)