### PR TITLE
Fix compilation of CUDA code on macOS

### DIFF
--- a/gloo/cuda_private.cu
+++ b/gloo/cuda_private.cu
@@ -8,7 +8,10 @@
 
 #include "gloo/cuda_private.h"
 
+#include <array>
+
 #include <cuda.h>
+
 // Disable strict aliasing errors for CUDA 9.
 #if CUDA_VERSION >= 9000
 #ifdef __GNUC__

--- a/gloo/cuda_private.h
+++ b/gloo/cuda_private.h
@@ -13,7 +13,9 @@
 #include <memory>
 #include <mutex>
 
+#ifdef __linux__
 #include "gloo/common/linux.h"
+#endif
 #include "gloo/common/logging.h"
 #include "gloo/cuda.h"
 #include "gloo/transport/device.h"
@@ -64,8 +66,12 @@ int findCudaDevicePointerClosestToDevice(
   int minDistance = INT_MAX;
   int minDistanceCount = 0;
   for (auto i = 0; i < ptrs.size(); i++) {
+#ifdef __linux__
     auto cudaBusID = getCudaPCIBusID(ptrs[i].getDeviceID());
     distance[i] = pciDistance(devBusID, cudaBusID);
+#else
+    distance[i] = 0;
+#endif
     if (distance[i] <= minDistance) {
       if (distance[i] < minDistance) {
         minDistance = distance[i];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#216 Fix compilation of CUDA code on macOS**
* #215 Use uv_os_gethostname instead of gethostname
* #214 Fix mismatch between declaration and definition
* #213 Make libuv detection code more robust

The code that determines PCI distance between a GPU and a network
device is only available on Linux. If not available, we default the
distance to be 0 everywhere.

Differential Revision: [D17153545](https://our.internmc.facebook.com/intern/diff/D17153545)