### PR TITLE
Pass write operation to lambda by reference

### DIFF
--- a/gloo/transport/uv/pair.cc
+++ b/gloo/transport/uv/pair.cc
@@ -373,7 +373,10 @@ void Pair::writeOp(Op op) {
   // insertion or deletion on either end of the deque (see std::deque).
   const auto& ref = writeOps_.back();
   auto handle = handle_;
-  device_->defer([handle, ref] {
+
+  // Beware that we pass ref by reference for above reason.
+  // If it were a copy, the preamble would be invalid on lambda return.
+  device_->defer([handle, &ref] {
     handle->write((char*)&ref.preamble, sizeof(ref.preamble));
 
     // Also write buffer if applicable.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #221 Publish event prior to potentially calling uv_read_stop
* **#220 Pass write operation to lambda by reference**

Tricky bug: this was passed by value before, which caused
the operation preamble to be vulnerable to clobbering once
the lambda returned. Per the comment about taking a reference the
intent was correct, but the implementation was flawed.

Differential Revision: [D17626454](https://our.internmc.facebook.com/intern/diff/D17626454)