### PR TITLE
Publish event prior to potentially calling uv_read_stop

### DIFF
--- a/gloo/transport/uv/libuv.cc
+++ b/gloo/transport/uv/libuv.cc
@@ -37,13 +37,12 @@ void TCP::uv__read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
     auto& segment = ref.reads_.front();
     segment.read(nread);
     if (segment.done()) {
-      auto event = segment.event();
+      ref.publish(segment.event());
       ref.reads_.pop_front();
       if (ref.reads_.empty()) {
         auto rv = uv_read_stop(ref.template get<uv_stream_t>());
         UV_ASSERT(rv, "uv_read_stop");
       }
-      ref.publish(std::move(event));
     }
   } else if (nread == UV_EOF) {
     ref.publish(EndEvent{});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#221 Publish event prior to potentially calling uv_read_stop**
* #220 Pass write operation to lambda by reference

Doing so means the application can queue a new read and we don't have
to ping-pong between uv_read_start and uv_read_stop.

Differential Revision: [D17626453](https://our.internmc.facebook.com/intern/diff/D17626453)