### PR TITLE
Only set c++11 if not already set to c++14

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -165,7 +165,7 @@ foreach(diag cc_clobber_ignored integer_sign_change useless_using_declaration se
   gloo_list_append_if_unique(CUDA_NVCC_FLAGS -Xcudafe --diag_suppress=${diag})
 endforeach()
 
-# Set C++11 support
+# If the project including us doesn't set any -std=xxx directly, we set it to C++11 here.
 set(CUDA_PROPAGATE_HOST_FLAGS OFF)
 if((NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+") AND (NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=gnu\\+\\+"))
   gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-std=c++11")

--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -167,7 +167,9 @@ endforeach()
 
 # Set C++11 support
 set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-std=c++11")
+if((NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+") AND (NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=gnu\\+\\+"
+  gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-std=c++11")
+endif()
 gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-Xcompiler -fPIC")
 
 mark_as_advanced(CUDA_BUILD_CUBIN CUDA_BUILD_EMULATION CUDA_VERBOSE_BUILD)

--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -167,7 +167,7 @@ endforeach()
 
 # Set C++11 support
 set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-if((NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+") AND (NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=gnu\\+\\+"
+if((NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+") AND (NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=gnu\\+\\+"))
   gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-std=c++11")
 endif()
 gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-Xcompiler -fPIC")


### PR DESCRIPTION
This allows projects using this to specify c++14 or c++17 for their cuda files without it conflicting here.

Test Plan: My PR switching PyTorch to C++14 (https://github.com/pytorch/pytorch/pull/27864) has a lot of errors right now but fewer errors with this change (i.e. the gloo dependency builds correctly after this change).