### PR TITLE
Update and move remote pending operation accounting

### DIFF
--- a/gloo/context.cc
+++ b/gloo/context.cc
@@ -10,6 +10,8 @@
 
 #include "gloo/common/error.h"
 #include "gloo/common/logging.h"
+#include "gloo/transport/device.h"
+#include "gloo/transport/unbound_buffer.h"
 
 namespace gloo {
 

--- a/gloo/context.h
+++ b/gloo/context.h
@@ -8,14 +8,20 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <vector>
 
-#include "gloo/transport/context.h"
-#include "gloo/transport/device.h"
-#include "gloo/transport/pair.h"
+#include <gloo/transport/pair.h>
 
 namespace gloo {
+
+// There is no need to materialize all transport types here.
+namespace transport {
+class Context;
+class Device;
+class UnboundBuffer;
+}
 
 class Context {
  public:
@@ -49,7 +55,6 @@ class Context {
   std::shared_ptr<transport::Context> transportContext_;
   int slot_;
   std::chrono::milliseconds timeout_;
-
 };
 
 } // namespace gloo

--- a/gloo/transport/context.cc
+++ b/gloo/transport/context.cc
@@ -22,5 +22,90 @@ std::unique_ptr<transport::Pair>& Context::getPair(int rank) {
   return pairs_.at(rank);
 }
 
+Context::LazyTally::LazyTally(std::vector<Tally>& vec, slot_t slot)
+    : vec_(vec), slot_(slot), initialized_(false) {}
+
+Context::LazyTally::~LazyTally() {
+  // Remove empty tally from vector.
+  if (initialized_ && it_ != vec_.end() && it_->empty()) {
+    vec_.erase(it_);
+  }
+}
+
+bool Context::LazyTally::exists() {
+  initialize_iterator();
+  return it_ != vec_.end();
+}
+
+Context::Tally& Context::LazyTally::get() {
+  initialize_iterator();
+  if (it_ == vec_.end()) {
+    vec_.emplace_back(slot_);
+    it_ = (vec_.end() - 1);
+  }
+  return *it_;
+}
+
+void Context::LazyTally::initialize_iterator() {
+  if (initialized_) {
+    return;
+  }
+
+  it_ =
+      std::find_if(vec_.begin(), vec_.end(), [this](const Context::Tally& op) {
+        return op.slot == slot_;
+      });
+  initialized_ = true;
+}
+
+Context::Mutator::Mutator(Context& context, slot_t slot, rank_t rank)
+    : lock_(context.mutex_),
+      context_(context),
+      slot_(slot),
+      rank_(rank),
+      pendingOperations_(context_.pendingOperations_, slot_),
+      expectedNotifications_(context_.expectedNotifications_, slot_) {}
+
+void Context::Mutator::pushRemotePendingRecv() {
+  pendingOperations_.get().pushRecv(rank_);
+}
+
+void Context::Mutator::pushRemotePendingSend() {
+  pendingOperations_.get().pushSend(rank_);
+}
+
+bool Context::Mutator::shiftRemotePendingRecv() {
+  if (!pendingOperations_.exists()) {
+    return false;
+  }
+  return pendingOperations_.get().shiftRecv(rank_);
+}
+
+bool Context::Mutator::shiftRemotePendingSend() {
+  if (!pendingOperations_.exists()) {
+    return false;
+  }
+  return pendingOperations_.get().shiftSend(rank_);
+}
+
+void Context::Mutator::pushExpectedSendNotification() {
+  expectedNotifications_.get().pushSend(rank_);
+}
+
+bool Context::Mutator::shiftExpectedSendNotification() {
+  if (!expectedNotifications_.exists()) {
+    return false;
+  }
+  return expectedNotifications_.get().shiftSend(rank_);
+}
+
+std::vector<Context::Tally>::iterator Context::findPendingOperations(
+    slot_t slot) {
+  return std::find_if(
+      pendingOperations_.begin(),
+      pendingOperations_.end(),
+      [slot](const Tally& op) { return op.slot == slot; });
+}
+
 } // namespace transport
 } // namespace gloo

--- a/gloo/transport/context.h
+++ b/gloo/transport/context.h
@@ -8,8 +8,14 @@
 
 #pragma once
 
+#include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <functional>
 #include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 #include "gloo/transport/pair.h"
 #include "gloo/transport/unbound_buffer.h"
@@ -18,17 +24,19 @@ namespace gloo {
 namespace transport {
 
 // The context represents a set of pairs that belong to the same
-// group. Its equivalent class at the top level namespace represents
-// the same group but cannot represent transport specifics.
+// group. It is roughly equivalent to the top level context class
+// with the exception that it captures transport specifics.
 //
 // While implementing the recv-from-any functionality we realized we
 // realized we needed some transport-specific state shared between all
 // pairs in a group, to arbitrate between multiple pairs attempting to
-// send to the same buffer. To avoid over-generalization, transports
-// can implement this however they want in their own subclass.
+// send to the same buffer.
 //
 class Context {
  public:
+  using slot_t = uint64_t;
+  using rank_t = int;
+
   Context(int rank, int size);
 
   virtual ~Context();
@@ -58,6 +66,19 @@ class Context {
   }
 
  protected:
+  // Protects access to the pending operations and expected
+  // notifications vectors. These vectors can only be mutated by an
+  // instance of the Context::Mutator class, which acquires this lock
+  // upon construction.
+  //
+  // The vector of pairs is logically const and may be accessed
+  // without holding this lock.
+  //
+  // If this lock is acquired from a function on a Pair class, ensure
+  // that Pair's instance lock is acquired before acquiring this lock.
+  //
+  std::mutex mutex_;
+
   // Lifecycle of the pairs is managed by a std::unique_ptr of the
   // base class. This is done because the public context API dictates
   // that getPair() returns a reference to this type. Functions
@@ -68,6 +89,201 @@ class Context {
   // Default timeout for new pairs (e.g. during initialization) and
   // any kind of send/recv operation.
   std::chrono::milliseconds timeout_;
+
+ protected:
+  // Keep track of pending send and recv notifications or operations
+  // for a single slot.
+  //
+  // The order with which ranks register a pending operation is
+  // preserved to avoid starvation for recv-from-any operations.
+  //
+  class Tally final {
+   private:
+    // This class stores the ranks with pending operations against
+    // this slot. The parent class uses two instances: one for send
+    // operations and one for receive operations.
+    //
+    // Adding ranks with a pending operation is done through the
+    // `push` method, which adds the rank to the end of the list.
+    // Removing ranks with a pending operation is done through the
+    // `shift` method, which removes a specific rank from the
+    // beginning of the list. The caller must know the rank to remove
+    // prior to calling `shift`, because a receive operation may be
+    // limited to a subset of ranks.
+    //
+    class List final {
+     public:
+      bool empty() const {
+        return ranks_.empty();
+      }
+
+      const std::vector<rank_t>& list() const {
+        return ranks_;
+      }
+
+      // Push rank to the end of the list.
+      void push(rank_t rank) {
+        ranks_.push_back(rank);
+      }
+
+      // Shift rank from the beginning of the list.
+      // Returns if the rank could be found and was removed.
+      bool shift(rank_t rank) {
+        auto it = std::find(ranks_.begin(), ranks_.end(), rank);
+        if (it != ranks_.end()) {
+          ranks_.erase(it);
+          return true;
+        }
+        return false;
+      }
+
+     private:
+      std::vector<rank_t> ranks_;
+    };
+
+   public:
+    explicit Tally(slot_t slot) : slot(slot) {}
+
+    slot_t slot;
+
+    bool empty() const {
+      return send_.empty() && recv_.empty();
+    }
+
+    const std::vector<rank_t>& getSendList() const {
+      return send_.list();
+    }
+
+    const std::vector<rank_t>& getRecvList() const {
+      return recv_.list();
+    }
+
+    void pushSend(rank_t rank) {
+      send_.push(rank);
+    }
+
+    void pushRecv(rank_t rank) {
+      recv_.push(rank);
+    }
+
+    bool shiftSend(rank_t rank) {
+      return send_.shift(rank);
+    }
+
+    bool shiftRecv(rank_t rank) {
+      return recv_.shift(rank);
+    }
+
+   private:
+    List send_;
+    List recv_;
+  };
+
+  // This class is used to locate a tally for a specific slot in a
+  // vector container. If the tally if needed and doesn't exist, it
+  // may be lazily created. If, on destruction, the tally that this
+  // class points to is empty, it is removed from the container.
+  //
+  // This functionality is needed both for the pending operation tally
+  // and for the expected notification tally. Therefore, we chose to
+  // use a somewhat generalized class, over duplicating the same
+  // functionality for two identical containers.
+  //
+  class LazyTally final {
+   public:
+    LazyTally(std::vector<Tally>& vec, slot_t slot);
+
+    ~LazyTally();
+
+    // Returns if a Tally instance exists for the specified slot.
+    bool exists();
+
+    // Returns pointer to Tally instance for the specified slot.
+    // Lazily constructs a new instance if needed.
+    Tally& get();
+
+   private:
+    // Reference to underlying container.
+    std::vector<Tally>& vec_;
+
+    // Slot for the tally we're interested in.
+    const slot_t slot_;
+
+    // Iterator to tally for the specified slot.
+    std::vector<Tally>::iterator it_;
+
+    // If the iterator has been initialized.
+    bool initialized_;
+
+    // Initialize iterator to Tally instance for this slot.
+    void initialize_iterator();
+  };
+
+  // This class is used to mutate the pending operation tally and
+  // expected notification tally for a specific source rank against a
+  // specific slot. An instance is expected to have a short lifetime
+  // as it holds a lock on the parent context object.
+  class Mutator final {
+   public:
+    Mutator(Context& context, slot_t slot, rank_t rank);
+
+    void pushRemotePendingRecv();
+
+    void pushRemotePendingSend();
+
+    bool shiftRemotePendingRecv();
+
+    bool shiftRemotePendingSend();
+
+    // When posting a receive operation, we first check if a send
+    // notification for the specified slot was already received. If
+    // not, it may already been in flight, and we must take care to
+    // ignore it when it arrives. This function ensures that the next
+    // send notification for this slot is ignored.
+    //
+    // Also see `shiftExpectedSendNotification`.
+    //
+    void pushExpectedSendNotification();
+
+    // This function returns whether or not we were expecting a send
+    // notification for this slot. If we do, we can ignore it.
+    //
+    // Also see `pushExpectedSendNotification`.
+    //
+    bool shiftExpectedSendNotification();
+
+   private:
+    std::lock_guard<std::mutex> lock_;
+    Context& context_;
+    const slot_t slot_;
+    const rank_t rank_;
+
+    // Find and mutate pending operation tally.
+    LazyTally pendingOperations_;
+
+    // Find and mutate expected notification tally.
+    LazyTally expectedNotifications_;
+  };
+
+  // The pending operation tally is stored as a vector under the
+  // assumption that we're working with very few of them. It should be
+  // cheaper to perform a linear search in contiguous memory than it
+  // is to maintain a map of them and pay a higher mutation overhead.
+  std::vector<Tally> pendingOperations_;
+
+  // If a recv operation is posted before the corresponding send
+  // notification is received, then we need to make sure the send
+  // notification isn't added to the pending operations vector. To do
+  // so, we maintain a structure of notifications we expect to
+  // receive, so that they can be dropped when they are.
+  std::vector<Tally> expectedNotifications_;
+
+  // Permit the mutator class to touch the pending operation tally.
+  friend class Mutator;
+
+ protected:
+  // Return iterator to pending operation tally for specific slot.
+  std::vector<Tally>::iterator findPendingOperations(slot_t slot);
 };
 
 } // namespace transport

--- a/gloo/transport/tcp/context.cc
+++ b/gloo/transport/tcp/context.cc
@@ -18,60 +18,6 @@ namespace gloo {
 namespace transport {
 namespace tcp {
 
-using count_t = PendingOpCount::count_t;
-
-ContextMutator::ContextMutator(Context& context, size_t slot, size_t rank)
-    : lock_(context.m_),
-      context_(context),
-      slot_(slot),
-      rank_(rank),
-      it_(context_.remotePendingOp_.find(slot)) {}
-
-ContextMutator::~ContextMutator() {
-  if (it_ != context_.remotePendingOp_.end() && it_->second.empty()) {
-    context_.remotePendingOp_.erase(it_);
-  }
-}
-
-count_t ContextMutator::getRemotePendingRecv() {
-  if (it_ == context_.remotePendingOp_.end()) {
-    return 0;
-  }
-  return it_->second.getRecv(rank_);
-}
-
-count_t ContextMutator::getRemotePendingSend() {
-  if (it_ == context_.remotePendingOp_.end()) {
-    return 0;
-  }
-  return it_->second.getSend(rank_);
-}
-
-count_t ContextMutator::updateRemotePendingRecv(count_t v) {
-  auto it = insertIfNotExists();
-  return it->second.updateRecv(rank_, v);
-}
-
-count_t ContextMutator::updateRemotePendingSend(count_t v) {
-  auto it = insertIfNotExists();
-  return it->second.updateSend(rank_, v);
-}
-
-ContextMutator::PendingOpCountIterator ContextMutator::insertIfNotExists() {
-  if (it_ == context_.remotePendingOp_.end()) {
-    std::tie(it_, std::ignore) =
-        context_.remotePendingOp_.emplace(slot_, PendingOpCount(context_.size));
-  }
-  return it_;
-}
-
-bool ContextMutator::findRecvFromAny(
-    WeakNonOwningPtr<UnboundBuffer>* buf,
-    size_t* offset,
-    size_t* nbytes) {
-  return context_.findRecvFromAny(slot_, rank_, buf, offset, nbytes);
-}
-
 Context::Context(std::shared_ptr<Device> device, int rank, int size)
     : ::gloo::transport::Context(rank, size), device_(std::move(device)) {}
 
@@ -124,23 +70,26 @@ int Context::recvFromAnyFindRank(
     size_t offset,
     size_t nbytes,
     const std::vector<int>& srcRanks) {
-  std::unique_lock<std::mutex> lock(m_);
+  std::unique_lock<std::mutex> lock(mutex_);
 
-  // See if there is a pending remote send that can fulfill this recv.
-  auto it = remotePendingOp_.find(slot);
-  if (it != remotePendingOp_.end()) {
-    auto& remotePendingOps = it->second;
+  // See if there is a remote pending send that can fulfill this recv.
+  auto it = findPendingOperations(slot);
+  if (it != pendingOperations_.end()) {
+    auto& pendingOperation = *it;
 
-    // Doing a linear search to find eligible ranks is suboptimal in
-    // terms of performance but is functionally correct.
-    for (const auto& srcRank : srcRanks) {
-      if (remotePendingOps.getSend(srcRank) > 0) {
-        // We've found a rank that could fulfill this recv.
-        //
-        // The caller of this function will try and attempt a recv
-        // which will decrement the remote pending sends counter.
-        //
-        return srcRank;
+    // Out of all remote pending sends, find the first one
+    // that exists in the set of eligible ranks.
+    for (const auto rank : pendingOperation.getSendList()) {
+      for (const auto srcRank : srcRanks) {
+        if (rank == srcRank) {
+          // We've found a rank that could fulfill this recv.
+          //
+          // The caller of this function will try and attempt a recv,
+          // which will remove this remote pending send operation,
+          // if it's still around.
+          //
+          return rank;
+        }
       }
     }
   }

--- a/gloo/transport/tcp/context.h
+++ b/gloo/transport/tcp/context.h
@@ -22,150 +22,11 @@ namespace gloo {
 namespace transport {
 namespace tcp {
 
-// PendingOpCount keeps track of the number of remote pending
-// operations (both pending send and receive operations) for a single
-// slot, across all pairs. This used to be tracked in the pairs
-// themselves, but to support receive-from-any we need a centralized
-// view into all pending send operations. This class facilitaties that
-// centralized view for both pending send and receive operations.
-//
-// The count for a slot is accessed through the transport context
-// object defined further down in this file.
-//
-class PendingOpCount final {
- public:
-  using count_t = int8_t;
-
- private:
-  // Counts either pending send or pending recv operations.
-  // Keeps track of number of non-zero entries such that
-  // instances with all zero counts can be cleaned up.
-  class Count final {
-   public:
-    explicit Count(size_t length) : count_(length), nonzero_(0) {}
-
-    bool empty() const {
-      return nonzero_ == 0;
-    }
-
-    count_t get(size_t rank) const {
-      return count_[rank];
-    }
-
-    // Update the count for the specified rank.
-    // If the count for this rank changes from zero to non-zero, it
-    // increments the non-zero counter. If it changes from non-zero to
-    // zero, it decrements the non-zero counter.
-    count_t update(size_t rank, count_t v) {
-      auto cur = count_[rank];
-      if (cur == 0) {
-        cur += v;
-        if (cur != 0) {
-          nonzero_++;
-        }
-      } else {
-        cur += v;
-        if (cur == 0) {
-          nonzero_--;
-        }
-      }
-      count_[rank] = cur;
-      return cur;
-    }
-
-   private:
-    std::vector<count_t> count_;
-    ssize_t nonzero_;
-  };
-
- public:
-  explicit PendingOpCount(size_t length) : send_(length), recv_(length) {}
-
-  bool empty() {
-    return send_.empty() && recv_.empty();
-  }
-
-  count_t getSend(size_t rank) {
-    return send_.get(rank);
-  }
-
-  count_t getRecv(size_t rank) {
-    return recv_.get(rank);
-  }
-
-  count_t updateSend(size_t rank, count_t v) {
-    return send_.update(rank, v);
-  }
-
-  count_t updateRecv(size_t rank, count_t v) {
-    return recv_.update(rank, v);
-  }
-
- private:
-  Count send_;
-  Count recv_;
-};
-
 // Forward declaration
 class Context;
 class Device;
 class Pair;
 class UnboundBuffer;
-
-// Short lived object that is returned to Pair functions. It has a
-// lock on the context object so that it can atomically retrieve and
-// mutate the pending operation count as well as check for pending
-// send or receive operations.
-//
-// Slots are often ephemeral identifiers. This object lazily creates
-// pending op count entries for new slots, and removes them if they
-// are no longer needed. Destroyed entries may be recreated later.
-//
-// The object is expected to be destructed as soon as it leaves scope.
-//
-class ContextMutator {
-  using count_t = PendingOpCount::count_t;
-  using PendingOpCountMap = std::unordered_map<uint64_t, PendingOpCount>;
-  using PendingOpCountIterator = PendingOpCountMap::iterator;
-
- public:
-  ContextMutator(Context& context, uint64_t slot, uint64_t rank);
-
-  ~ContextMutator();
-
-  // Current number of remote pending recv operations for rank.
-  count_t getRemotePendingRecv();
-
-  // Current number of remote pending send operations for rank.
-  count_t getRemotePendingSend();
-
-  // Update number of remote pending recv operations by `v`.
-  count_t updateRemotePendingRecv(count_t v);
-
-  // Update number of remote pending send operations by `v`.
-  count_t updateRemotePendingSend(count_t v);
-
-  // Find buffer for which we should execute a recv operation.
-  bool findRecvFromAny(
-      WeakNonOwningPtr<UnboundBuffer>* buf,
-      size_t* offset,
-      size_t* nbytes);
-
- protected:
-  std::lock_guard<std::mutex> lock_;
-  Context& context_;
-  const uint64_t slot_;
-  const uint64_t rank_;
-
-  // Every operation that requires the ContextMutator will access the
-  // pending operation count. Therefore we can perform lookup of this
-  // object at construction time.
-  PendingOpCountIterator it_;
-
-  // If the existing iterator does not exists, insert new pending
-  // operation count object and return the new iterator.
-  PendingOpCountIterator insertIfNotExists();
-};
 
 class Context final : public ::gloo::transport::Context,
                       public std::enable_shared_from_this<Context> {
@@ -183,8 +44,6 @@ class Context final : public ::gloo::transport::Context,
  private:
   std::shared_ptr<Device> device_;
 
-  std::mutex m_;
-
   using pendingRecvTuple = std::tuple<
       WeakNonOwningPtr<UnboundBuffer>,
       size_t,
@@ -193,9 +52,6 @@ class Context final : public ::gloo::transport::Context,
 
   // Buffers with pending receive operation by slot.
   std::unordered_map<uint64_t, std::deque<pendingRecvTuple>> pendingRecv_;
-
-  // Pending remote operation count by slot number.
-  std::unordered_map<uint64_t, PendingOpCount> remotePendingOp_;
 
   // This function registers the specified unbound buffer for a receive
   // operation from any of the specified ranks.
@@ -230,6 +86,8 @@ class Context final : public ::gloo::transport::Context,
   friend class ContextMutator;
 
   friend class UnboundBuffer;
+
+  friend class Pair;
 };
 
 } // namespace tcp

--- a/gloo/transport/uv/context.h
+++ b/gloo/transport/uv/context.h
@@ -34,150 +34,11 @@ namespace gloo {
 namespace transport {
 namespace uv {
 
-// PendingOpCount keeps track of the number of remote pending
-// operations (both pending send and receive operations) for a single
-// slot, across all pairs. This used to be tracked in the pairs
-// themselves, but to support receive-from-any we need a centralized
-// view into all pending send operations. This class facilitaties that
-// centralized view for both pending send and receive operations.
-//
-// The count for a slot is accessed through the transport context
-// object defined further down in this file.
-//
-class PendingOpCount final {
- public:
-  using count_t = int8_t;
-
- private:
-  // Counts either pending send or pending recv operations.
-  // Keeps track of number of non-zero entries such that
-  // instances with all zero counts can be cleaned up.
-  class Count final {
-   public:
-    explicit Count(size_t length) : count_(length), nonzero_(0) {}
-
-    bool empty() const {
-      return nonzero_ == 0;
-    }
-
-    count_t get(size_t rank) const {
-      return count_[rank];
-    }
-
-    // Update the count for the specified rank.
-    // If the count for this rank changes from zero to non-zero, it
-    // increments the non-zero counter. If it changes from non-zero to
-    // zero, it decrements the non-zero counter.
-    count_t update(size_t rank, count_t v) {
-      auto cur = count_[rank];
-      if (cur == 0) {
-        cur += v;
-        if (cur != 0) {
-          nonzero_++;
-        }
-      } else {
-        cur += v;
-        if (cur == 0) {
-          nonzero_--;
-        }
-      }
-      count_[rank] = cur;
-      return cur;
-    }
-
-   private:
-    std::vector<count_t> count_;
-    ssize_t nonzero_;
-  };
-
- public:
-  explicit PendingOpCount(size_t length) : send_(length), recv_(length) {}
-
-  bool empty() {
-    return send_.empty() && recv_.empty();
-  }
-
-  count_t getSend(size_t rank) {
-    return send_.get(rank);
-  }
-
-  count_t getRecv(size_t rank) {
-    return recv_.get(rank);
-  }
-
-  count_t updateSend(size_t rank, count_t v) {
-    return send_.update(rank, v);
-  }
-
-  count_t updateRecv(size_t rank, count_t v) {
-    return recv_.update(rank, v);
-  }
-
- private:
-  Count send_;
-  Count recv_;
-};
-
 // Forward declaration
 class Context;
 class Device;
 class Pair;
 class UnboundBuffer;
-
-// Short lived object that is returned to Pair functions. It has a
-// lock on the context object so that it can atomically retrieve and
-// mutate the pending operation count as well as check for pending
-// send or receive operations.
-//
-// Slots are often ephemeral identifiers. This object lazily creates
-// pending op count entries for new slots, and removes them if they
-// are no longer needed. Destroyed entries may be recreated later.
-//
-// The object is expected to be destructed as soon as it leaves scope.
-//
-class ContextMutator {
-  using count_t = PendingOpCount::count_t;
-  using PendingOpCountMap = std::unordered_map<uint64_t, PendingOpCount>;
-  using PendingOpCountIterator = PendingOpCountMap::iterator;
-
- public:
-  ContextMutator(Context& context, uint64_t slot, uint64_t rank);
-
-  ~ContextMutator();
-
-  // Current number of remote pending recv operations for rank.
-  count_t getRemotePendingRecv();
-
-  // Current number of remote pending send operations for rank.
-  count_t getRemotePendingSend();
-
-  // Update number of remote pending recv operations by `v`.
-  count_t updateRemotePendingRecv(count_t v);
-
-  // Update number of remote pending send operations by `v`.
-  count_t updateRemotePendingSend(count_t v);
-
-  // Find buffer for which we should execute a recv operation.
-  bool findRecvFromAny(
-      WeakNonOwningPtr<UnboundBuffer>* buf,
-      size_t* offset,
-      size_t* nbytes);
-
- protected:
-  std::lock_guard<std::mutex> lock_;
-  Context& context_;
-  const uint64_t slot_;
-  const uint64_t rank_;
-
-  // Every operation that requires the ContextMutator will access the
-  // pending operation count. Therefore we can perform lookup of this
-  // object at construction time.
-  PendingOpCountIterator it_;
-
-  // If the existing iterator does not exists, insert new pending
-  // operation count object and return the new iterator.
-  PendingOpCountIterator insertIfNotExists();
-};
 
 class Context final : public ::gloo::transport::Context,
                       public std::enable_shared_from_this<Context> {
@@ -195,8 +56,6 @@ class Context final : public ::gloo::transport::Context,
  private:
   std::shared_ptr<Device> device_;
 
-  std::mutex m_;
-
   using pendingRecvTuple = std::tuple<
       WeakNonOwningPtr<UnboundBuffer>,
       size_t,
@@ -205,9 +64,6 @@ class Context final : public ::gloo::transport::Context,
 
   // Buffers with pending receive operation by slot.
   std::unordered_map<uint64_t, std::deque<pendingRecvTuple>> pendingRecv_;
-
-  // Pending remote operation count by slot number.
-  std::unordered_map<uint64_t, PendingOpCount> remotePendingOp_;
 
   // This function registers the specified unbound buffer for a receive
   // operation from any of the specified ranks.
@@ -237,6 +93,8 @@ class Context final : public ::gloo::transport::Context,
   friend class ContextMutator;
 
   friend class UnboundBuffer;
+
+  friend class Pair;
 };
 
 } // namespace uv


### PR DESCRIPTION
Accounting for remote pending operations was the responsibility of the
transport specific context class. This is essentially identical across
transports, though, so this commit moves the logic out of the two
transport implementations and into the base class.

Second, the original approach could lead to starvation on
recv-from-any calls. Because pending operations were counted keyed off
the remote rank, low ranks would take precedence over high ranks. This
commit changes that such that ranks are serviced in the same order in
which their send notifications are received.