### PR TITLE
Add abortWaitSend/abortWaitRecv to unbound_buffer

### DIFF
--- a/gloo/test/send_recv_test.cc
+++ b/gloo/test/send_recv_test.cc
@@ -235,6 +235,79 @@ TEST_P(SendRecvTest, RecvFromAny) {
   });
 }
 
+TEST_P(SendRecvTest, AbortRecv) {
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  constexpr uint64_t slot = 0x1337;
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    // Test that an unbounded buffer should be able to abort its own waitRecv.
+    if (context->rank == 0) {
+      bool recvCompleted;
+      int srcRank = -1;
+      int tmp;
+      auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
+
+      std::thread waitRecvThreadAbort(
+          [&]() { recvCompleted = buf->waitRecv(&srcRank); });
+      buf->abortWaitRecv();
+      waitRecvThreadAbort.join();
+      ASSERT_FALSE(recvCompleted);
+
+      // Future waitRecvs should not be aborted if we received one abortWaitRecv
+      // previously
+      std::thread waitRecvThread([&]() {
+        std::vector<int> ranks = {1};
+        buf->recv(ranks, slot);
+        recvCompleted = buf->waitRecv(&srcRank);
+      });
+      waitRecvThread.join();
+      ASSERT_TRUE(recvCompleted);
+    } else if (context->rank == 1) {
+      // Send to rank 0
+      int tmp = context->rank;
+      auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
+      buf->send(0, slot);
+      buf->waitSend();
+    }
+  });
+}
+
+TEST_P(SendRecvTest, AbortSend) {
+  const auto transport = std::get<0>(GetParam());
+  const auto contextSize = std::get<1>(GetParam());
+  constexpr uint64_t slot = 0x1337;
+  spawn(transport, contextSize, [&](std::shared_ptr<Context> context) {
+    // Test that an unbounded buffer should be able to abort its own waitSend
+    bool sendCompleted;
+    if (context->rank == 0) {
+      int tmp;
+      auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
+
+      std::thread waitSendThreadAbort(
+          [&]() { sendCompleted = buf->waitSend(); });
+      buf->abortWaitSend();
+      waitSendThreadAbort.join();
+      ASSERT_FALSE(sendCompleted);
+
+      // Future wait sends should not be aborted if we received one abortSend
+      // previously
+      std::thread waitSendThread([&]() {
+        // Send to rank 1
+        buf->send(1, slot);
+        sendCompleted = buf->waitSend();
+      });
+      waitSendThread.join();
+      ASSERT_TRUE(sendCompleted);
+    } else if (context->rank == 1) {
+      // Receive from rank 0
+      int tmp = context->rank;
+      auto buf = context->createUnboundBuffer(&tmp, sizeof(tmp));
+      int srcRank = 0;
+      buf->recv(srcRank, slot);
+    }
+  });
+}
+
 TEST_P(SendRecvTest, RecvFromAnyOffset) {
   const auto transport = std::get<0>(GetParam());
   const auto contextSize = std::get<1>(GetParam());

--- a/gloo/transport/tcp/unbound_buffer.cc
+++ b/gloo/transport/tcp/unbound_buffer.cc
@@ -39,7 +39,19 @@ void UnboundBuffer::handleRecvCompletion(int rank) {
   recvCv_.notify_one();
 }
 
-void UnboundBuffer::waitRecv(int* rank, std::chrono::milliseconds timeout) {
+void UnboundBuffer::abortWaitRecv() {
+  std::lock_guard<std::mutex> guard(m_);
+  abortWaitRecv_ = true;
+  recvCv_.notify_one();
+}
+
+void UnboundBuffer::abortWaitSend() {
+  std::lock_guard<std::mutex> guard(m_);
+  abortWaitSend_ = true;
+  sendCv_.notify_one();
+}
+
+bool UnboundBuffer::waitRecv(int* rank, std::chrono::milliseconds timeout) {
   std::unique_lock<std::mutex> lock(m_);
   if (timeout == kUnsetTimeout) {
     timeout = context_->getTimeout();
@@ -48,7 +60,7 @@ void UnboundBuffer::waitRecv(int* rank, std::chrono::milliseconds timeout) {
   if (recvCompletions_ == 0) {
     auto done = recvCv_.wait_for(lock, timeout, [&] {
       throwIfException();
-      return recvCompletions_ > 0;
+      return abortWaitRecv_ || recvCompletions_ > 0;
     });
     if (!done) {
       // Below, we let all pairs in the transport context know about this
@@ -72,11 +84,16 @@ void UnboundBuffer::waitRecv(int* rank, std::chrono::milliseconds timeout) {
                   "ms for recv operation to complete"));
     }
   }
-
+  if (abortWaitRecv_) {
+    // Reset to false, so that only this waitRecv is interrupted
+    abortWaitRecv_ = false;
+    return false;
+  }
   recvCompletions_--;
   if (rank != nullptr) {
     *rank = recvRank_;
   }
+  return true;
 }
 
 void UnboundBuffer::handleSendCompletion(int rank) {
@@ -86,7 +103,7 @@ void UnboundBuffer::handleSendCompletion(int rank) {
   sendCv_.notify_one();
 }
 
-void UnboundBuffer::waitSend(int* rank, std::chrono::milliseconds timeout) {
+bool UnboundBuffer::waitSend(int* rank, std::chrono::milliseconds timeout) {
   std::unique_lock<std::mutex> lock(m_);
   if (timeout == kUnsetTimeout) {
     timeout = context_->getTimeout();
@@ -95,7 +112,7 @@ void UnboundBuffer::waitSend(int* rank, std::chrono::milliseconds timeout) {
   if (sendCompletions_ == 0) {
     auto done = sendCv_.wait_for(lock, timeout, [&] {
         throwIfException();
-        return sendCompletions_ > 0;
+        return abortWaitSend_ || sendCompletions_ > 0;
       });
     if (!done) {
       // Below, we let all pairs in the transport context know about this
@@ -120,10 +137,16 @@ void UnboundBuffer::waitSend(int* rank, std::chrono::milliseconds timeout) {
     }
   }
 
+  if (abortWaitSend_) {
+    // Reset to false, so that only this waitSend is interrupted
+    abortWaitSend_ = false;
+    return false;
+  }
   sendCompletions_--;
   if (rank != nullptr) {
     *rank = sendRank_;
   }
+  return true;
 }
 
 void UnboundBuffer::send(

--- a/gloo/transport/tcp/unbound_buffer.h
+++ b/gloo/transport/tcp/unbound_buffer.h
@@ -33,10 +33,18 @@ class UnboundBuffer : public ::gloo::transport::UnboundBuffer {
   virtual ~UnboundBuffer();
 
   // If specified, the source of this recv is stored in the rank pointer.
-  void waitRecv(int* rank, std::chrono::milliseconds timeout) override;
+  // Returns true if it completed, false if it was aborted.
+  bool waitRecv(int* rank, std::chrono::milliseconds timeout) override;
 
   // If specified, the destination of this send is stored in the rank pointer.
-  void waitSend(int* rank, std::chrono::milliseconds timeout) override;
+  // Returns true if it completed, false if it was aborted.
+  bool waitSend(int* rank, std::chrono::milliseconds timeout) override;
+
+  // Aborts a pending waitRecv call.
+  void abortWaitRecv() override;
+
+  // Aborts a pending waitSend call.
+  void abortWaitSend() override;
 
   void send(int dstRank, uint64_t slot, size_t offset, size_t nbytes)
       override;
@@ -59,6 +67,8 @@ class UnboundBuffer : public ::gloo::transport::UnboundBuffer {
   std::mutex m_;
   std::condition_variable recvCv_;
   std::condition_variable sendCv_;
+  bool abortWaitRecv_{false};
+  bool abortWaitSend_{false};
 
   int recvCompletions_;
   int recvRank_;

--- a/gloo/transport/unbound_buffer.h
+++ b/gloo/transport/unbound_buffer.h
@@ -38,52 +38,60 @@ class UnboundBuffer {
   const size_t size;
 
   // If specified, the source of this recv is stored in the rank pointer.
-  virtual void waitRecv(int* rank, std::chrono::milliseconds timeout) = 0;
+  // Returns true if it completed, false if it was aborted.
+  virtual bool waitRecv(int* rank, std::chrono::milliseconds timeout) = 0;
 
   // If specified, the destination of this send is stored in the rank pointer.
-  virtual void waitSend(int* rank, std::chrono::milliseconds timeout) = 0;
+  // Returns true if it completed, false if it was aborted.
+  virtual bool waitSend(int* rank, std::chrono::milliseconds timeout) = 0;
+
+  // Aborts a pending waitRecv call.
+  virtual void abortWaitRecv() = 0;
+
+  // Aborts a pending waitSend call.
+  virtual void abortWaitSend() = 0;
 
   // Default overload.
-  void waitRecv() {
-    waitRecv(nullptr, kUnsetTimeout);
+  bool waitRecv() {
+    return waitRecv(nullptr, kUnsetTimeout);
   }
 
   // Default overload.
-  void waitSend() {
-    waitSend(nullptr, kUnsetTimeout);
+  bool waitSend() {
+    return waitSend(nullptr, kUnsetTimeout);
   }
 
   // Rank overload.
-  void waitRecv(int* rank) {
-    waitRecv(rank, kUnsetTimeout);
+  bool waitRecv(int* rank) {
+    return waitRecv(rank, kUnsetTimeout);
   }
 
   // Rank overload.
-  void waitSend(int* rank) {
-    waitSend(rank, kUnsetTimeout);
+  bool waitSend(int* rank) {
+    return waitSend(rank, kUnsetTimeout);
   }
 
   // Timeout overload.
-  void waitRecv(std::chrono::milliseconds timeout) {
-    waitRecv(nullptr, timeout);
+  bool waitRecv(std::chrono::milliseconds timeout) {
+    return waitRecv(nullptr, timeout);
   }
 
   // Timeout overload.
-  void waitSend(std::chrono::milliseconds timeout) {
-    waitSend(nullptr, timeout);
+  bool waitSend(std::chrono::milliseconds timeout) {
+    return waitSend(nullptr, timeout);
   }
 
   // Deadline overload.
   template <typename clock>
-  void waitRecv(std::chrono::time_point<clock> deadline) {
-    waitRecv(std::chrono::duration_cast<std::chrono::milliseconds>(
+  bool waitRecv(std::chrono::time_point<clock> deadline) {
+    return waitRecv(std::chrono::duration_cast<std::chrono::milliseconds>(
         deadline - clock::now()));
   }
 
   // Deadline overload.
   template <typename clock>
-  void waitSend(std::chrono::time_point<clock> deadline) {
-    waitSend(std::chrono::duration_cast<std::chrono::milliseconds>(
+  bool waitSend(std::chrono::time_point<clock> deadline) {
+    return waitSend(std::chrono::duration_cast<std::chrono::milliseconds>(
         deadline - clock::now()));
   }
 

--- a/gloo/transport/uv/unbound_buffer.cc
+++ b/gloo/transport/uv/unbound_buffer.cc
@@ -39,15 +39,27 @@ void UnboundBuffer::handleRecvCompletion(int rank) {
   recvCv_.notify_one();
 }
 
-void UnboundBuffer::waitRecv(int* rank, std::chrono::milliseconds timeout) {
+void UnboundBuffer::abortWaitRecv() {
+  std::lock_guard<std::mutex> guard(m_);
+  abortWaitRecv_ = true;
+  recvCv_.notify_one();
+}
+
+void UnboundBuffer::abortWaitSend() {
+  std::lock_guard<std::mutex> guard(m_);
+  abortWaitSend_ = true;
+  sendCv_.notify_one();
+}
+
+bool UnboundBuffer::waitRecv(int* rank, std::chrono::milliseconds timeout) {
   std::unique_lock<std::mutex> lock(mutex_);
   if (timeout == kUnsetTimeout) {
     timeout = context_->getTimeout();
   }
 
   if (recvCompletions_ == 0) {
-    auto done =
-        recvCv_.wait_for(lock, timeout, [&] { return recvCompletions_ > 0; });
+    auto done = recvCv_.wait_for(
+        lock, timeout, [&] { return abortWaitRecv_ || recvCompletions_ > 0; });
     if (!done) {
       throw ::gloo::IoException(GLOO_ERROR_MSG(
           "Timed out waiting ",
@@ -56,10 +68,16 @@ void UnboundBuffer::waitRecv(int* rank, std::chrono::milliseconds timeout) {
     }
   }
 
+  if (abortWaitRecv_) {
+    // Reset to false, so that only this waitRecv is interrupted
+    abortWaitRecv_ = false;
+    return false;
+  }
   recvCompletions_--;
   if (rank != nullptr) {
     *rank = recvRank_;
   }
+  return true;
 }
 
 void UnboundBuffer::handleSendCompletion(int rank) {
@@ -69,15 +87,15 @@ void UnboundBuffer::handleSendCompletion(int rank) {
   sendCv_.notify_one();
 }
 
-void UnboundBuffer::waitSend(int* rank, std::chrono::milliseconds timeout) {
+bool UnboundBuffer::waitSend(int* rank, std::chrono::milliseconds timeout) {
   std::unique_lock<std::mutex> lock(mutex_);
   if (timeout == kUnsetTimeout) {
     timeout = context_->getTimeout();
   }
 
   if (sendCompletions_ == 0) {
-    auto done =
-        sendCv_.wait_for(lock, timeout, [&] { return sendCompletions_ > 0; });
+    auto done = sendCv_.wait_for(
+        lock, timeout, [&] { return abortWaitSend_ || sendCompletions_ > 0; });
     if (!done) {
       throw ::gloo::IoException(GLOO_ERROR_MSG(
           "Timed out waiting ",
@@ -86,10 +104,16 @@ void UnboundBuffer::waitSend(int* rank, std::chrono::milliseconds timeout) {
     }
   }
 
+  if (abortWaitSend_) {
+    // Reset to false, so that only this waitSend is interrupted
+    abortWaitSend_ = false;
+    return false;
+  }
   sendCompletions_--;
   if (rank != nullptr) {
     *rank = sendRank_;
   }
+  return true;
 }
 
 void UnboundBuffer::send(

--- a/gloo/transport/uv/unbound_buffer.h
+++ b/gloo/transport/uv/unbound_buffer.h
@@ -31,10 +31,18 @@ class UnboundBuffer : public ::gloo::transport::UnboundBuffer {
   virtual ~UnboundBuffer();
 
   // If specified, the source of this recv is stored in the rank pointer.
-  void waitRecv(int* rank, std::chrono::milliseconds timeout) override;
+  // Returns true if it completed, false if it was aborted.
+  bool waitRecv(int* rank, std::chrono::milliseconds timeout) override;
 
   // If specified, the destination of this send is stored in the rank pointer.
-  void waitSend(int* rank, std::chrono::milliseconds timeout) override;
+  // Returns true if it completed, false if it was aborted.
+  bool waitSend(int* rank, std::chrono::milliseconds timeout) override;
+
+  // Aborts a pending waitRecv call.
+  void abortWaitRecv() override;
+
+  // Aborts a pending waitSend call.
+  void abortWaitSend() override;
 
   void send(int dstRank, uint64_t tag, size_t offset, size_t nbytes = 0)
       override;
@@ -57,6 +65,8 @@ class UnboundBuffer : public ::gloo::transport::UnboundBuffer {
   std::mutex mutex_;
   std::condition_variable recvCv_;
   std::condition_variable sendCv_;
+  bool abortWaitRecv_{false};
+  bool abortWaitSend_{false};
 
   int recvCompletions_;
   int recvRank_;


### PR DESCRIPTION
Summary: Closes #227.
Adds 2 methods: `abortWaitSend`, `abortWaitRecv` so that we can interrupt a blocking `waitRecv` or `waitSend`, per @pietern 's suggestion. This is useful if a gloo process is waiting for a message in one thread, but another thread decides to shutdown and wants to stop it gracefully.

The methods set a boolean variable and notify a waiting condition variable. The condition variable predicate is changed to check this condition. The implementation is both for the tcp and uv transport methods. Unit tests are also added.

Differential Revision: D18210908

