### PR TITLE
Make gloo::transport::tcp::Pair::changeState noexcept(true)

### DIFF
--- a/gloo/transport/tcp/pair.h
+++ b/gloo/transport/tcp/pair.h
@@ -287,7 +287,7 @@ class Pair : public ::gloo::transport::Pair {
   //
   // The pair mutex is expected to be held when called.
   //
-  void changeState(state nextState);
+  void changeState(state nextState) noexcept;
 
   // Helper function to block execution until the pair has advanced to
   // the `CONNECTED` state. Expected to be called from `Pair::connect`.


### PR DESCRIPTION
Summary:
If `Pair::listen` encounters an error it calls signal and throw
exception. Signaling an exception means closing the pair, which in
turn calls `Pair::changeState` to move to the CLOSED state. The code
in this function would throw if the current state is equal to
INITIALIZING, which would mask the exception that `Pair::listen`
intended to throw. This is solved by making `Pair::changeState`
noexcept(true) and updating the state selection code in its body.

Differential Revision: D18807092

