### PR TITLE
Create and use epoll(2) handler base class

### DIFF
--- a/.tsan-suppressions
+++ b/.tsan-suppressions
@@ -1,3 +1,11 @@
 race:gloo::transport::tcp::Pair::read
 race:gloo::transport::tcp::Pair::write
 race:gloo::transport::tcp::Address::operator=
+
+# After adding a handler base class, tsan thinks that
+# the pair's destructor (operator delete) races with
+# a vtable access in the epoll thread. This doesn't
+# race because the pair ensures that the epoll thread
+# won't call into it before its destructor returns.
+# See https://github.com/facebookincubator/gloo/pull/236.
+race:gloo::transport::tcp::Pair::~Pair

--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -258,12 +258,12 @@ std::shared_ptr<transport::Context> Device::createContext(
       new tcp::Context(shared_from_this(), rank, size));
 }
 
-void Device::registerDescriptor(int fd, int events, Pair* p) {
+void Device::registerDescriptor(int fd, int events, Handler* h) {
   struct epoll_event ev;
   int rv;
 
   ev.events = events;
-  ev.data.ptr = p;
+  ev.data.ptr = h;
 
   rv = epoll_ctl(fd_, EPOLL_CTL_ADD, fd, &ev);
   if (rv == -1 && errno == EEXIST) {
@@ -310,8 +310,8 @@ void Device::loop() {
     GLOO_ENFORCE_NE(nfds, -1);
 
     for (int i = 0; i < nfds; i++) {
-      Pair* p = reinterpret_cast<Pair*>(events[i].data.ptr);
-      p->handleEvents(events[i].events);
+      Handler* h = reinterpret_cast<Handler*>(events[i].data.ptr);
+      h->handleEvents(events[i].events);
     }
   }
 }

--- a/gloo/transport/tcp/device.h
+++ b/gloo/transport/tcp/device.h
@@ -53,6 +53,8 @@ class Buffer;
 // instances and didn't need to dispatch events to different types.
 class Handler {
 public:
+  virtual ~Handler() = default;
+
   virtual void handleEvents(int events) = 0;
 };
 

--- a/gloo/transport/tcp/device.h
+++ b/gloo/transport/tcp/device.h
@@ -46,6 +46,16 @@ std::shared_ptr<::gloo::transport::Device> CreateDevice(
 class Pair;
 class Buffer;
 
+// Handler abstract base class called by the epoll(2) event loop.
+// Dispatch to multiple types is needed because we must deal with a
+// single listening socket on the device instance and I/O for all pair
+// instances. Before this approach, we'd exclusively deal with `Pair`
+// instances and didn't need to dispatch events to different types.
+class Handler {
+public:
+  virtual void handleEvents(int events) = 0;
+};
+
 class Device : public ::gloo::transport::Device,
                public std::enable_shared_from_this<Device> {
  public:
@@ -64,7 +74,7 @@ class Device : public ::gloo::transport::Device,
  protected:
   void loop();
 
-  void registerDescriptor(int fd, int events, Pair* p);
+  void registerDescriptor(int fd, int events, Handler* h);
   void unregisterDescriptor(int fd);
 
   const struct attr attr_;

--- a/gloo/transport/tcp/pair.h
+++ b/gloo/transport/tcp/pair.h
@@ -75,7 +75,7 @@ struct Op {
   size_t nbytes = 0;
 };
 
-class Pair : public ::gloo::transport::Pair {
+class Pair : public ::gloo::transport::Pair, public Handler {
   enum state {
     INITIALIZING = 1,
     LISTENING = 2,
@@ -136,7 +136,7 @@ class Pair : public ::gloo::transport::Pair {
       size_t offset,
       size_t nbytes);
 
-  void handleEvents(int events);
+  void handleEvents(int events) override;
 
   void close() override;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #243 Use a single listening socket per device
* #242 Add error class
* #241 Add RAII wrapper for socket
* #240 Allow deferring functions to the epoll(2) thread
* #239 Add sequence number to gloo::transport::tcp::Address
* #238 Move attr struct to own header
* #237 Move event loop to loop.{cc,h}
* **#236 Create and use epoll(2) handler base class**

Dispatch to multiple types is needed because we must deal with a
single listening socket on the device instance and I/O for all pair
instances. Before this approach, we'd exclusively deal with `Pair`
instances and didn't need to dispatch events to different types.

Differential Revision: [D18909051](https://our.internmc.facebook.com/intern/diff/D18909051)