### PR TITLE
Move event loop to loop.{cc,h}

### DIFF
--- a/gloo/transport/tcp/CMakeLists.txt
+++ b/gloo/transport/tcp/CMakeLists.txt
@@ -6,6 +6,7 @@ else()
       "${CMAKE_CURRENT_SOURCE_DIR}/buffer.cc"
       "${CMAKE_CURRENT_SOURCE_DIR}/context.cc"
       "${CMAKE_CURRENT_SOURCE_DIR}/device.cc"
+      "${CMAKE_CURRENT_SOURCE_DIR}/loop.cc"
       "${CMAKE_CURRENT_SOURCE_DIR}/pair.cc"
       "${CMAKE_CURRENT_SOURCE_DIR}/unbound_buffer.cc"
       )
@@ -14,6 +15,7 @@ else()
       "${CMAKE_CURRENT_SOURCE_DIR}/buffer.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/context.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/device.h"
+      "${CMAKE_CURRENT_SOURCE_DIR}/loop.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/pair.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/unbound_buffer.h"
       )

--- a/gloo/transport/tcp/loop.cc
+++ b/gloo/transport/tcp/loop.cc
@@ -20,7 +20,7 @@ namespace gloo {
 namespace transport {
 namespace tcp {
 
-Loop::Loop() : fd_(-1), done_(false) {
+Loop::Loop() {
   fd_ = epoll_create(1);
   GLOO_ENFORCE_NE(fd_, -1, "epoll_create: ", strerror(errno));
   loop_.reset(new std::thread(&Loop::run, this));

--- a/gloo/transport/tcp/loop.cc
+++ b/gloo/transport/tcp/loop.cc
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gloo/transport/tcp/loop.h>
+
+#include <string.h>
+#include <unistd.h>
+
+#include <array>
+
+#include <gloo/common/error.h>
+#include <gloo/common/logging.h>
+
+namespace gloo {
+namespace transport {
+namespace tcp {
+
+Loop::Loop() : fd_(-1), done_(false) {
+  fd_ = epoll_create(1);
+  GLOO_ENFORCE_NE(fd_, -1, "epoll_create: ", strerror(errno));
+  loop_.reset(new std::thread(&Loop::run, this));
+}
+
+Loop::~Loop() {
+  if (loop_) {
+    done_ = true;
+    loop_->join();
+  }
+  if (fd_ >= 0) {
+    close(fd_);
+  }
+}
+
+void Loop::registerDescriptor(int fd, int events, Handler* h) {
+  struct epoll_event ev;
+  ev.events = events;
+  ev.data.ptr = h;
+
+  auto rv = epoll_ctl(fd_, EPOLL_CTL_ADD, fd, &ev);
+  if (rv == -1 && errno == EEXIST) {
+    rv = epoll_ctl(fd_, EPOLL_CTL_MOD, fd, &ev);
+  }
+  GLOO_ENFORCE_NE(rv, -1, "epoll_ctl: ", strerror(errno));
+}
+
+void Loop::unregisterDescriptor(int fd) {
+  auto rv = epoll_ctl(fd_, EPOLL_CTL_DEL, fd, nullptr);
+  GLOO_ENFORCE_NE(rv, -1, "epoll_ctl: ", strerror(errno));
+
+  // Wait for loop to tick before returning, to make sure the handler
+  // for this fd is not called once this function returns.
+  if (std::this_thread::get_id() != loop_->get_id()) {
+    std::unique_lock<std::mutex> lock(m_);
+    cv_.wait(lock);
+  }
+}
+
+void Loop::run() {
+  std::array<struct epoll_event, capacity_> events;
+  int nfds;
+
+  while (!done_) {
+    // Wakeup everyone waiting for a loop tick to finish.
+    cv_.notify_all();
+
+    // Wait for something to happen
+    nfds = epoll_wait(fd_, events.data(), events.size(), 10);
+    if (nfds == 0) {
+      continue;
+    }
+    if (nfds == -1 && errno == EINTR) {
+      continue;
+    }
+
+    GLOO_ENFORCE_NE(nfds, -1);
+
+    for (int i = 0; i < nfds; i++) {
+      Handler* h = reinterpret_cast<Handler*>(events[i].data.ptr);
+      h->handleEvents(events[i].events);
+    }
+  }
+}
+
+} // namespace tcp
+} // namespace transport
+} // namespace gloo

--- a/gloo/transport/tcp/loop.h
+++ b/gloo/transport/tcp/loop.h
@@ -47,8 +47,8 @@ class Loop final : public std::enable_shared_from_this<Loop> {
  private:
   static constexpr auto capacity_ = 64;
 
-  int fd_;
-  std::atomic<bool> done_;
+  int fd_{-1};
+  std::atomic<bool> done_{false};
   std::unique_ptr<std::thread> loop_;
 
   std::mutex m_;

--- a/gloo/transport/tcp/loop.h
+++ b/gloo/transport/tcp/loop.h
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include <sys/epoll.h>
+
+namespace gloo {
+namespace transport {
+namespace tcp {
+
+// Handler abstract base class called by the epoll(2) event loop.
+// Dispatch to multiple types is needed because we must deal with a
+// single listening socket on the device instance and I/O for all pair
+// instances. Before this approach, we'd exclusively deal with `Pair`
+// instances and didn't need to dispatch events to different types.
+class Handler {
+ public:
+  virtual void handleEvents(int events) = 0;
+};
+
+class Loop final : public std::enable_shared_from_this<Loop> {
+ public:
+  explicit Loop();
+
+  ~Loop();
+
+  void registerDescriptor(int fd, int events, Handler* h);
+
+  void unregisterDescriptor(int fd);
+
+  void run();
+
+ private:
+  static constexpr auto capacity_ = 64;
+
+  int fd_;
+  std::atomic<bool> done_;
+  std::unique_ptr<std::thread> loop_;
+
+  std::mutex m_;
+  std::condition_variable cv_;
+};
+
+} // namespace tcp
+} // namespace transport
+} // namespace gloo


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #243 Use a single listening socket per device
* #242 Add error class
* #241 Add RAII wrapper for socket
* #240 Allow deferring functions to the epoll(2) thread
* #239 Add sequence number to gloo::transport::tcp::Address
* #238 Move attr struct to own header
* **#237 Move event loop to loop.{cc,h}**
* #236 Create and use epoll(2) handler base class



Differential Revision: [D18909100](https://our.internmc.facebook.com/intern/diff/D18909100)