### PR TITLE
Move attr struct to own header

### DIFF
--- a/gloo/transport/tcp/CMakeLists.txt
+++ b/gloo/transport/tcp/CMakeLists.txt
@@ -12,6 +12,7 @@ else()
       )
     list(APPEND GLOO_TRANSPORT_HDRS
       "${CMAKE_CURRENT_SOURCE_DIR}/address.h"
+      "${CMAKE_CURRENT_SOURCE_DIR}/attr.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/buffer.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/context.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/device.h"

--- a/gloo/transport/tcp/attr.h
+++ b/gloo/transport/tcp/attr.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <sys/socket.h>
+
+namespace gloo {
+namespace transport {
+namespace tcp {
+
+struct attr {
+  attr() {}
+  /* implicit */ attr(const char* ptr) : hostname(ptr) {}
+
+  std::string hostname;
+
+  std::string iface;
+
+  // The address family defaults to AF_UNSPEC such that getaddrinfo(3)
+  // will try to find either IPv4 or IPv6 addresses.
+  int ai_family = AF_UNSPEC;
+  int ai_socktype;
+  int ai_protocol;
+  struct sockaddr_storage ai_addr;
+  int ai_addrlen;
+};
+
+} // namespace tcp
+} // namespace transport
+} // namespace gloo

--- a/gloo/transport/tcp/device.h
+++ b/gloo/transport/tcp/device.h
@@ -14,31 +14,13 @@
 #include <mutex>
 #include <thread>
 
-#include <sys/socket.h>
-
 #include <gloo/transport/device.h>
+#include <gloo/transport/tcp/attr.h>
 #include <gloo/transport/tcp/loop.h>
 
 namespace gloo {
 namespace transport {
 namespace tcp {
-
-struct attr {
-  attr() {}
-  /* implicit */ attr(const char* ptr) : hostname(ptr) {}
-
-  std::string hostname;
-
-  std::string iface;
-
-  // The address family defaults to AF_UNSPEC such that getaddrinfo(3)
-  // will try to find either IPv4 or IPv6 addresses.
-  int ai_family = AF_UNSPEC;
-  int ai_socktype;
-  int ai_protocol;
-  struct sockaddr_storage ai_addr;
-  int ai_addrlen;
-};
 
 std::shared_ptr<::gloo::transport::Device> CreateDevice(
     const struct attr&);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #243 Use a single listening socket per device
* #242 Add error class
* #241 Add RAII wrapper for socket
* #240 Allow deferring functions to the epoll(2) thread
* #239 Add sequence number to gloo::transport::tcp::Address
* **#238 Move attr struct to own header**
* #237 Move event loop to loop.{cc,h}
* #236 Create and use epoll(2) handler base class



Differential Revision: [D18909101](https://our.internmc.facebook.com/intern/diff/D18909101)