### PR TITLE
Add sequence number to gloo::transport::tcp::Address

### DIFF
--- a/gloo/rendezvous/context.h
+++ b/gloo/rendezvous/context.h
@@ -14,6 +14,7 @@
 #include "gloo/common/error.h"
 #include "gloo/context.h"
 #include "gloo/rendezvous/store.h"
+#include "gloo/transport/address.h"
 #include "gloo/transport/device.h"
 
 namespace gloo {
@@ -38,8 +39,8 @@ class Context : public ::gloo::Context {
 
 class ContextFactory {
  public:
-  // Assume a pair's address is no bigger than 128 bytes
-  static constexpr auto kMaxAddressSize = 128;
+  static constexpr auto kMaxAddressSize =
+      ::gloo::transport::Address::kMaxByteSize;
 
   explicit ContextFactory(std::shared_ptr<::gloo::Context> backingContext);
 

--- a/gloo/transport/address.h
+++ b/gloo/transport/address.h
@@ -16,6 +16,9 @@ namespace transport {
 
 class Address {
  public:
+  // Upper bound for an address' byte representation.
+  static constexpr auto kMaxByteSize = 192;
+
   virtual ~Address() = 0;
 
   virtual std::string str() const = 0;

--- a/gloo/transport/tcp/address.cc
+++ b/gloo/transport/tcp/address.cc
@@ -63,7 +63,7 @@ std::string Address::str() const {
 
   // Append sequence number if one is set.
   if (impl_.seq != SIZE_MAX) {
-    len += snprintf(str + len, sizeof(str) - len, "$%d", impl_.seq);
+    len += snprintf(str + len, sizeof(str) - len, "$%ld", impl_.seq);
   }
 
   return str;

--- a/gloo/transport/tcp/address.h
+++ b/gloo/transport/tcp/address.h
@@ -28,8 +28,6 @@ class Address : public ::gloo::transport::Address {
 
   explicit Address(const std::vector<char>&);
 
-  virtual ~Address() = default;
-
   virtual std::vector<char> bytes() const override;
 
   virtual std::string str() const override;

--- a/gloo/transport/tcp/address.h
+++ b/gloo/transport/tcp/address.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <sys/socket.h>
+#include <unistd.h>
 
 #include "gloo/transport/address.h"
 
@@ -16,7 +17,7 @@ namespace gloo {
 namespace transport {
 namespace tcp {
 
-using sequence_number_t = int;
+using sequence_number_t = ssize_t;
 
 class Address : public ::gloo::transport::Address {
  public:
@@ -59,6 +60,7 @@ class Address : public ::gloo::transport::Address {
   };
 
   static_assert(std::is_trivially_copyable<Impl>::value, "!");
+  static_assert(sizeof(Impl) <= kMaxByteSize, "!");
 
   Impl impl_;
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #243 Use a single listening socket per device
* #242 Add error class
* #241 Add RAII wrapper for socket
* #240 Allow deferring functions to the epoll(2) thread
* **#239 Add sequence number to gloo::transport::tcp::Address**
* #238 Move attr struct to own header
* #237 Move event loop to loop.{cc,h}
* #236 Create and use epoll(2) handler base class



Differential Revision: [D18909096](https://our.internmc.facebook.com/intern/diff/D18909096)