### PR TITLE
remove throw will always call terminate() warning

### DIFF
--- a/gloo/nccl/nccl.cu
+++ b/gloo/nccl/nccl.cu
@@ -97,7 +97,7 @@ NCCLExecution<T>::NCCLExecution(std::vector<NCCLElement<T>>&& elements)
 }
 
 template <typename T>
-NCCLExecution<T>::~NCCLExecution() {
+NCCLExecution<T>::~NCCLExecution() noexcept(false) {
   for (auto i = 0; i < this->elements.size(); i++) {
     CudaDeviceScope scope(this->elements[i].device);
     CUDA_CHECK(cudaEventDestroy(ncclEvents[i]));

--- a/gloo/nccl/nccl.h
+++ b/gloo/nccl/nccl.h
@@ -73,7 +73,7 @@ class NCCLExecution {
  public:
   /* implicit */ NCCLExecution(std::vector<NCCLElement<T>>&& elements);
   NCCLExecution(NCCLExecution&&) = default;
-  ~NCCLExecution();
+  ~NCCLExecution() noexcept(false);
 
   std::vector<int> getDevices() const;
   std::string getKey() const;


### PR DESCRIPTION
Summary:
Remove warnings like
```
gloo/cuda.cu:226:342: warning: throw will always call terminate() [-Wterminate]
```

Differential Revision: D20185029

