### PR TITLE
Annotate throwing destructors with `noexcept(false)`

### DIFF
--- a/gloo/algorithm.cc
+++ b/gloo/algorithm.cc
@@ -21,7 +21,7 @@ Algorithm::Algorithm(const std::shared_ptr<Context>& context)
       contextSize_(context_->size) {}
 
 // Have to provide implementation for pure virtual destructor.
-Algorithm::~Algorithm() {}
+Algorithm::~Algorithm() noexcept(false) {}
 
 std::unique_ptr<transport::Pair>& Algorithm::getPair(int i) {
   return context_->getPair(i);

--- a/gloo/algorithm.h
+++ b/gloo/algorithm.h
@@ -20,7 +20,7 @@ extern const size_t kOnDeviceThreshold;
 class Algorithm {
  public:
   explicit Algorithm(const std::shared_ptr<Context>&);
-  virtual ~Algorithm() = 0;
+  virtual ~Algorithm() noexcept(false) = 0;
 
   virtual void run() = 0;
 
@@ -101,7 +101,7 @@ const ReductionFunction<T>* ReductionFunction<T>::max =
 template <typename T>
 class LocalOp {
  public:
-  virtual ~LocalOp() {}
+  virtual ~LocalOp() noexcept(false) {}
   virtual void runAsync() = 0;
   virtual void wait() = 0;
 

--- a/gloo/cuda.cu
+++ b/gloo/cuda.cu
@@ -72,7 +72,7 @@ CudaStream::CudaStream(CudaStream&& other) noexcept
   other.event_ = nullptr;
 }
 
-CudaStream::~CudaStream() {
+CudaStream::~CudaStream() noexcept(false) {
   if (deviceId_ == kInvalidDeviceId) {
     return;
   }
@@ -216,7 +216,7 @@ CudaDevicePointer<T>& CudaDevicePointer<T>::operator=(
 }
 
 template<typename T>
-CudaDevicePointer<T>::~CudaDevicePointer() {
+CudaDevicePointer<T>::~CudaDevicePointer() noexcept(false) {
   if (deviceId_ == kInvalidDeviceId) {
     return;
   }
@@ -266,7 +266,7 @@ CudaHostPointer<T>& CudaHostPointer<T>::operator=(CudaHostPointer<T>&& other) {
 }
 
 template<typename T>
-CudaHostPointer<T>::~CudaHostPointer() {
+CudaHostPointer<T>::~CudaHostPointer() noexcept(false) {
   if (owner_) {
     std::lock_guard<std::mutex> lock(CudaShared::getMutex());
     CUDA_CHECK(cudaFreeHost(host_));

--- a/gloo/cuda.h
+++ b/gloo/cuda.h
@@ -60,7 +60,7 @@ class CudaStream {
   // Move constructor
   CudaStream(CudaStream&& other) noexcept;
 
-  ~CudaStream();
+  ~CudaStream() noexcept(false);
 
   cudaStream_t operator*() const {
     return stream_;
@@ -125,7 +125,7 @@ class CudaDevicePointer {
   }
 
   CudaDevicePointer(CudaDevicePointer&&) noexcept;
-  ~CudaDevicePointer();
+  ~CudaDevicePointer() noexcept(false);
 
   // Default constructor creates invalid instance
   CudaDevicePointer()
@@ -195,7 +195,7 @@ class CudaHostPointer {
   }
 
   CudaHostPointer(CudaHostPointer&&) noexcept;
-  ~CudaHostPointer();
+  ~CudaHostPointer() noexcept(false);
 
   // Default constructor creates invalid instance
   CudaHostPointer() : CudaHostPointer(nullptr, 0, false) {}

--- a/gloo/cuda_private.cu
+++ b/gloo/cuda_private.cu
@@ -81,7 +81,7 @@ CudaMemory<T>::CudaMemory(CudaMemory<T>&& other) noexcept
 }
 
 template<typename T>
-CudaMemory<T>::~CudaMemory() {
+CudaMemory<T>::~CudaMemory() noexcept(false) {
   CudaDeviceScope scope(device_);
   if (ptr_ != nullptr) {
     // Sychronize memory allocation with NCCL operations

--- a/gloo/cuda_private.h
+++ b/gloo/cuda_private.h
@@ -99,7 +99,7 @@ class CudaDeviceGuard {
   CudaDeviceGuard() : previous_(getCurrentGPUID()) {
   }
 
-  ~CudaDeviceGuard() {
+  ~CudaDeviceGuard() noexcept(false) {
     CUDA_CHECK(cudaSetDevice(previous_));
   }
 
@@ -124,7 +124,7 @@ class CudaMemory {
  public:
   explicit CudaMemory(size_t elements);
   CudaMemory(CudaMemory&&) noexcept;
-  ~CudaMemory();
+  ~CudaMemory() noexcept(false);
 
   T* operator*() const {
     return ptr_;


### PR DESCRIPTION
In C++11 destructors default to `noexcept(true)`.
Both gcc and clang will treat `throw` in destructor as `terminate()` call

Test Plan: CI
