### PR TITLE
Pass -Xcompiler -fPIC as 2 separate arguments

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -170,7 +170,7 @@ set(CUDA_PROPAGATE_HOST_FLAGS OFF)
 if((NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+") AND (NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=gnu\\+\\+"))
   gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-std=c++11")
 endif()
-gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-Xcompiler -fPIC")
+gloo_list_append_if_unique(CUDA_NVCC_FLAGS "-Xcompiler" "-fPIC")
 
 mark_as_advanced(CUDA_BUILD_CUBIN CUDA_BUILD_EMULATION CUDA_VERBOSE_BUILD)
 mark_as_advanced(CUDA_SDK_ROOT_DIR CUDA_SEPARABLE_COMPILATION)


### PR DESCRIPTION
nvcc from CUDA-10.1 fails to parse "-Xcompiler -fPIC" passed as single argument:
```
$ nvcc -V; nvcc "-Xcompiler -fPIC"
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2019 NVIDIA Corporation
Built on Wed_Apr_24_19:10:27_PDT_2019
Cuda compilation tools, release 10.1, V10.1.168
nvcc fatal   : Unknown option 'Xcompiler -fPIC'
```

Test Plan: CI