### PR TITLE
Update Findrccl.cmake to fix warning

### DIFF
--- a/cmake/Modules/Findrccl.cmake
+++ b/cmake/Modules/Findrccl.cmake
@@ -40,7 +40,7 @@ find_library(RCCL_LIBRARY
   ${RCCL_ROOT_DIR}/lib)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(RCCL DEFAULT_MSG RCCL_INCLUDE_DIR RCCL_LIBRARY)
+find_package_handle_standard_args(rccl DEFAULT_MSG RCCL_INCLUDE_DIR RCCL_LIBRARY)
 
 if (RCCL_FOUND)
   set(RCCL_HEADER_FILE "${RCCL_INCLUDE_DIR}/rccl.h")


### PR DESCRIPTION
This clears the warning:
CMake Warning:
  The package name passed to `find_package_handle_standard_args` (RCCL) does
  not match the name of the calling package (rccl).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.