### PR TITLE
added <array> header

### DIFF
--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -8,6 +8,8 @@
 
 #include "gloo/transport/tcp/device.h"
 
+#include <array>
+
 #include <ifaddrs.h>
 #include <netdb.h>
 #include <netinet/in.h>


### PR DESCRIPTION
When trying to build the lib on ubuntu with cmake using clang++-11 with libc++, the following error occurs:

/home/lib/pytorch/third_party/gloo/gloo/transport/tcp/device.cc:152:39: error: implicit instantiation of undefined template 'std::__1::array<char, 64>'
      std::array<char, HOST_NAME_MAX> hostname;
                                      ^
/usr/lib/llvm-10/bin/../include/c++/v1/__tuple:219:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;

which is because the <array> header is absent in the gloo/transport/tcp/device.cc