### PR TITLE
Add benchmarking support for allreduce_local and alltoall

### DIFF
--- a/gloo/allreduce_local.cc
+++ b/gloo/allreduce_local.cc
@@ -48,5 +48,7 @@ INSTANTIATE_TEMPLATE(uint64_t);
 INSTANTIATE_TEMPLATE(float);
 INSTANTIATE_TEMPLATE(double);
 INSTANTIATE_TEMPLATE(float16);
+// Needed for benchmark (main.cc) to build, should not get used
+INSTANTIATE_TEMPLATE(char);
 
 } // namespace gloo

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -79,6 +79,8 @@ static void usage(int status, const char* argv0) {
   X("  allreduce_ring_chunked");
   X("  allreduce_halving_doubling");
   X("  allreduce_bcube");
+  X("  allreduce_local");
+  X("  all_to_all");
   X("  barrier_all_to_all");
   X("  broadcast_one_to_all");
   X("  pairwise_exchange");


### PR DESCRIPTION
Summary:
Currently, the Gloo Benchmark supports only a subset of all available collective algorithms. This diff adds benchmarking support for allreduce_local and alltoall.

- Added new cases in `RUN_BENCHMARK(T)`
- Updated usages in for `./benchmark --help`

- Support for **AllreduceLocal**:

This collective is very similar to pre-existing allreduce benchmarks (allreduce_ring, allreduce_ring_chunked, etc.) which all use the template class `AllreduceBenchmark`. Thus, support for AllreduceLocal is added by merely re-using this same class. The initialize and verify should be identical to the others.

The benchmark needs to support being run with type `char` for `pairwise_exchange`. Currently, `AllreduceLocal` does not instantiate a template for type `char` which caused errors. So, even though we should never hit this case for `AllreduceLocal`, it seems that the template must be instantiated for the benchmark to build successfully.

- Support for **Alltoall**:

Created a new class `AlltoallBenchmark` which inherits from `Benchmark`. It contains additional fields including: an options struct, size constants, and input/output vectors which are specific items required to configure the `AlltoallOptions`

The default `Benchmark::run` function calls the `Algorithm::run` function associated with the `algorithm_` we set in initialize. The remaining collectives do not inherit from `Algorithm` class which means that we need to override both the initialize and run functions.

In `initialize`, we create input and output vectors in a similar way to `alltoall_test.cc` and then  configure the options struct using those vectors. Then, in `run` we can just call the collective function on these options.

Differential Revision: D25980179

