### PR TITLE
Add benchmarking support for alltoallv

### DIFF
--- a/gloo/allreduce_local.cc
+++ b/gloo/allreduce_local.cc
@@ -48,5 +48,7 @@ INSTANTIATE_TEMPLATE(uint64_t);
 INSTANTIATE_TEMPLATE(float);
 INSTANTIATE_TEMPLATE(double);
 INSTANTIATE_TEMPLATE(float16);
+// Needed for benchmark (main.cc) to build, should not get used
+INSTANTIATE_TEMPLATE(char);
 
 } // namespace gloo

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -79,6 +79,8 @@ static void usage(int status, const char* argv0) {
   X("  allreduce_ring_chunked");
   X("  allreduce_halving_doubling");
   X("  allreduce_bcube");
+  X("  allreduce_local");
+  X("  alltoall");
   X("  barrier_all_to_all");
   X("  broadcast_one_to_all");
   X("  pairwise_exchange");

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -81,6 +81,7 @@ static void usage(int status, const char* argv0) {
   X("  allreduce_bcube");
   X("  allreduce_local");
   X("  alltoall");
+  X("  alltoall_v");
   X("  barrier_all_to_all");
   X("  broadcast_one_to_all");
   X("  pairwise_exchange");


### PR DESCRIPTION
Summary:
**This Diff:**

Adds benchmarking support for alltoallv.

- Added new cases in `RUN_BENCHMARK(T)`
- Updated usages in for `./benchmark --help`
- Support for `alltoallv`:

Created a new class `AllToAllvBenchmark` which inherits from `Benchmark`. It contains additional fields required to configure the `AlltoallvOptions`.

In `initialize`, we create vectors the same way done in `alltoallv_test.cc` and then configure the options struct using those vectors. In `run` we can just call the collective function on these options.

**This Stack:**

The purpose of this stack is to have a comprehensive benchmark for all collectives currently implemented (See list of missing benchmarks in task).

The default `Benchmark::run` function calls the `Algorithm::run` function associated with the `algorithm_` we set in initialize. The remaining missing collectives (with the exception of `AllreduceLocal`) do not inherit from `Algorithm` class which means that we need to override both the `initialize` and `run` functions.

Differential Revision: D25987688

