### PR TITLE
Add benchmarking support for broadcast, reduce, and scatter

### DIFF
--- a/gloo/allreduce_local.cc
+++ b/gloo/allreduce_local.cc
@@ -48,5 +48,7 @@ INSTANTIATE_TEMPLATE(uint64_t);
 INSTANTIATE_TEMPLATE(float);
 INSTANTIATE_TEMPLATE(double);
 INSTANTIATE_TEMPLATE(float16);
+// Needed for benchmark (main.cc) to build, should not get used
+INSTANTIATE_TEMPLATE(char);
 
 } // namespace gloo

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -75,6 +75,9 @@ static void usage(int status, const char* argv0) {
   X("      --base   The base for allreduce_bcube (if applicable)");
   X("");
   X("BENCHMARK is one of:");
+  X("  allgather");
+  X("  allgather_v");
+  X("  allgather_ring");
   X("  allreduce_ring");
   X("  allreduce_ring_chunked");
   X("  allreduce_halving_doubling");
@@ -85,6 +88,7 @@ static void usage(int status, const char* argv0) {
   X("  barrier_all_to_all");
   X("  broadcast_one_to_all");
   X("  pairwise_exchange");
+  X("  reduce_scatter");
   X("");
 
   exit(status);

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -79,6 +79,8 @@ static void usage(int status, const char* argv0) {
   X("  allreduce_ring_chunked");
   X("  allreduce_halving_doubling");
   X("  allreduce_bcube");
+  X("  allreduce_local");
+  X("  alltoall");
   X("  barrier_all_to_all");
   X("  broadcast_one_to_all");
   X("  pairwise_exchange");

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -86,9 +86,12 @@ static void usage(int status, const char* argv0) {
   X("  alltoall");
   X("  alltoall_v");
   X("  barrier_all_to_all");
+  X("  broadcast");
   X("  broadcast_one_to_all");
   X("  pairwise_exchange");
+  X("  reduce");
   X("  reduce_scatter");
+  X("  scatter");
   X("");
 
   exit(status);

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -81,6 +81,7 @@ static void usage(int status, const char* argv0) {
   X("  allreduce_bcube");
   X("  allreduce_local");
   X("  alltoall");
+  X("  alltoall_v");
   X("  barrier_all_to_all");
   X("  broadcast_one_to_all");
   X("  pairwise_exchange");


### PR DESCRIPTION
Summary:
**This Diff:**

Adds benchmarking support for broadcast, reduce, and scatter.

- Added new cases in `RUN_BENCHMARK(T)`
- Updated usages in for `./benchmark --help`
- Created a new classes `BroadcastBenchmark`, `ReduceBenchmark` and `ScatterBenchmark` which inherit from `Benchmark`. It contains additional fields required to configure the options struct required for the collective.

In `initialize`, we create the required variables and then configure the corresponding options struct using those. In `run` we can just call the collective function on these options.

**This Stack:**

The purpose of this stack is to have a comprehensive benchmark for all collectives currently implemented (See list of missing benchmarks in task).

The default `Benchmark::run` function calls the `Algorithm::run` function associated with the `algorithm_` we set in initialize. The remaining missing collectives (with the exception of `AllreduceLocal`) do not inherit from `Algorithm` class which means that we need to override both the `initialize` and `run` functions.

Differential Revision: D26020282

