### PR TITLE
Adding better error messages and comments for MultiProcessing helpers

### DIFF
--- a/gloo/test/multiproc_test.cc
+++ b/gloo/test/multiproc_test.cc
@@ -87,7 +87,7 @@ void MultiProcTest::spawnAsync(
 void MultiProcTest::signalProcess(int rank, int signal) {
   ASSERT_LT(rank, workers_.size());
   const auto result = kill(workers_[rank], signal);
-  ASSERT_EQ(0, result);
+  ASSERT_EQ(0, result) << "Unable to kill process with pid " << workers_[rank];
 }
 
 void MultiProcTest::wait() {
@@ -100,7 +100,7 @@ void MultiProcTest::waitProcess(int rank) {
   ASSERT_LT(rank, workers_.size());
   const auto& worker = workers_[rank];
   const auto& pid = waitpid(worker, &workerResults_[rank], 0);
-  ASSERT_EQ(pid, worker);
+  ASSERT_EQ(pid, worker) << "Encountered error while waiting for pid " << pid << " to change state.";
 }
 
 void MultiProcTest::spawn(

--- a/gloo/test/multiproc_test.h
+++ b/gloo/test/multiproc_test.h
@@ -31,7 +31,7 @@ class MultiProcTest : public ::testing::Test {
   void SetUp() override;
   void TearDown() override;
 
-  void spawnAsync(Transport transport, int size,
+  void spawnAsync(Transport transport, int numRanks,
                   std::function<void(std::shared_ptr<Context>)> fn);
   void wait();
   void waitProcess(int rank);

--- a/gloo/test/multiproc_test.h
+++ b/gloo/test/multiproc_test.h
@@ -31,19 +31,31 @@ class MultiProcTest : public ::testing::Test {
   void SetUp() override;
   void TearDown() override;
 
+  // Forks numRanks child processes that create a context of the defined
+  // transport and run the provided lambda function.
   void spawnAsync(Transport transport, int numRanks,
                   std::function<void(std::shared_ptr<Context>)> fn);
+
+  // Waits on each forked child process.
   void wait();
+
+  // Waits for the forked child process on the specified rank to change state.
   void waitProcess(int rank);
+
+  // Kills the specified process using the supplied signal.
   void signalProcess(int rank, int signal);
 
   int getResult(int rank) {
     return workerResults_[rank];
   }
 
+  // A single function that encapsulates spawnAsync to run the specified number
+  // of child processes, waiting for their completion, and asserting correct
+  // exit statuses.
   void spawn(Transport transport, int size, std::function<void(std::shared_ptr<Context>)> fn);
 
  private:
+  // Creates a MultiProcWorker to run the specified lambda.
   int runWorker(
       Transport transport,
       int size,
@@ -53,7 +65,11 @@ class MultiProcTest : public ::testing::Test {
   std::string storePath_;
   std::string semaphoreName_;
   sem_t* semaphore_;
+
+  // List of pid's for each forked child process.
   std::vector<pid_t> workers_;
+
+  // Holds the exit statuses for each child process.
   std::vector<int> workerResults_;
 };
 


### PR DESCRIPTION
Summary: The Multiproc test helpers currently do not include clear messages when syscalls fail. The helper methods and variables are not well commented, making the multiproc code difficult to extend.

Reviewed By: mingzhe09088

Differential Revision: D26011100

