### PR TITLE
Make localhost default device

### DIFF
--- a/gloo/test/base_test.cc
+++ b/gloo/test/base_test.cc
@@ -12,16 +12,18 @@
 namespace gloo {
 namespace test {
 
+const char *kDefaultDevice = "localhost";
+
 std::shared_ptr<::gloo::transport::Device> createDevice(Transport transport) {
 #if GLOO_HAVE_TRANSPORT_TCP
   if (transport == Transport::TCP) {
-    return ::gloo::transport::tcp::CreateDevice("localhost");
+    return ::gloo::transport::tcp::CreateDevice(kDefaultDevice);
   }
 #endif
 #if GLOO_HAVE_TRANSPORT_TCP_TLS
   if (transport == Transport::TCP_TLS) {
     return ::gloo::transport::tcp::tls::CreateDevice(
-        "localhost", pkey_file, cert_file, ca_cert_file, "");
+        kDefaultDevice, pkey_file, cert_file, ca_cert_file, "");
   }
 #endif
 #if GLOO_HAVE_TRANSPORT_UV
@@ -31,7 +33,7 @@ std::shared_ptr<::gloo::transport::Device> createDevice(Transport transport) {
     attr.ai_family = AF_UNSPEC;
     return ::gloo::transport::uv::CreateDevice(attr);
 #else
-    return ::gloo::transport::uv::CreateDevice("localhost");
+    return ::gloo::transport::uv::CreateDevice(kDefaultDevice);
 #endif
   }
 #endif

--- a/gloo/test/tls_tcp_test.cc
+++ b/gloo/test/tls_tcp_test.cc
@@ -18,6 +18,8 @@ namespace gloo {
 namespace test {
 namespace {
 
+const char *kDefaultDevice = "localhost";
+
 class TlsTcpTest : public BaseTest {};
 
 TEST_F(TlsTcpTest, CreateDeviceWithAllEmptyFilePaths) {
@@ -25,7 +27,7 @@ TEST_F(TlsTcpTest, CreateDeviceWithAllEmptyFilePaths) {
   try {
     ::gloo::rendezvous::HashStore store;
     auto device =
-        ::gloo::transport::tcp::tls::CreateDevice("localhost", "", "", "", "");
+        ::gloo::transport::tcp::tls::CreateDevice(kDefaultDevice, "", "", "", "");
     auto context = device->createContext(0, 1);
   } catch (::gloo::EnforceNotMet e) {
     exception_thrown = true;
@@ -41,7 +43,7 @@ TEST_F(TlsTcpTest, CreateDeviceWithCAEmptyFilePaths) {
   try {
     ::gloo::rendezvous::HashStore store;
     auto device = ::gloo::transport::tcp::tls::CreateDevice(
-        "localhost", pkey_file, cert_file, "", "");
+        kDefaultDevice, pkey_file, cert_file, "", "");
     auto context = device->createContext(0, 1);
   } catch (::gloo::EnforceNotMet e) {
     exception_thrown = true;
@@ -53,7 +55,7 @@ TEST_F(TlsTcpTest, CreateDeviceWithCAEmptyFilePaths) {
 
 TEST_F(TlsTcpTest, CreateDeviceWithUnknownCA) {
   auto device = ::gloo::transport::tcp::tls::CreateDevice(
-      "localhost", pkey_file, cert_file, cert_file, "");
+      kDefaultDevice, pkey_file, cert_file, cert_file, "");
   auto context = device->createContext(0, 2);
   auto &pair0 = context->createPair(0);
   auto addrBytes0 = pair0->address().bytes();


### PR DESCRIPTION
Summary: "localhost" serves as a floating string constant throughout the gloo test codebase. Consolidating this into the `kDefaultDevice` constant. In the future, we could add this to a more generic utils header that all the tests import?

Differential Revision: D26091783

