### PR TITLE
Add benchmarking support for p2p communications (send/recv roundtrip)

### DIFF
--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -30,6 +30,7 @@ static void usage(int status, const char* argv0) {
   X("");
   X("Participation:");
   X("  -s, --size=SIZE        Number of processes");
+  X("                         Note: Need exactly two processes for sendrecv benchmarks");
   X("  -r, --rank=RANK        Rank of this process");
   X("");
   X("Rendezvous:");
@@ -94,6 +95,7 @@ static void usage(int status, const char* argv0) {
   X("  reduce");
   X("  reduce_scatter");
   X("  scatter");
+  X("  sendrecv_roundtrip");
   X("");
 
   exit(status);


### PR DESCRIPTION
Summary:
**This diff:**
- adds a roundtrip benchmark for send/recv
- updated `--help` to reflect new benchmark
- added check to ensure exactly two processes are being used with send/recv benchmarks
- new constants for re-use in future p2p benchmarks

**This stack:**
The purpose of this stack is to add support for various benchmarks for p2p communications (send/recv/isend/irecv)

Differential Revision: D26257569

