### PR TITLE
Add benchmarking support for p2p communications (send/recv stress test)

### DIFF
--- a/gloo/benchmark/main.cc
+++ b/gloo/benchmark/main.cc
@@ -58,7 +58,7 @@ constexpr uint64_t kSendRecvProcesses = 2;
 // constant strings for error messages
 const std::string kMismatchErrorString = "Mismatch at index: ";
 const std::string kNumProcessesErrorString =
-  "Incorrect number of processes used for send/recv benchmarks: ";
+  "Incorrect number of processes used for send/recv benchmarks (please use 2 processes): ";
 
 // Verify function used for AllgatherBenchmark and
 // AllgatherRingBenchmark. The result/output from both
@@ -738,6 +738,88 @@ class SendRecvRoundtripBenchmark : public Benchmark<T> {
   const int source_ = 0;
 };
 
+// This benchmark shows the time it takes to send
+// a large number (default 10000, can be set from command line)
+// of messages of size elements from point A->B.
+// Can be run synchronously or asynchronously.
+template <typename T>
+class SendRecvStressBenchmark : public Benchmark<T> {
+  using Benchmark<T>::Benchmark;
+ public:
+  SendRecvStressBenchmark(
+    std::shared_ptr<::gloo::Context>& context,
+    struct options& options,
+    bool async)
+      : Benchmark<T>(context, options),
+        async_(async) {}
+
+  void initialize(size_t elements) override {
+    auto ptr = this->allocate(this->options_.inputs, elements);
+    buf_ = this->context_->createUnboundBuffer(ptr.front(), elements * sizeof(T));
+  }
+
+  void run() override {
+    const int niters = this->options_.messages;
+    // Only send on process with rank 0
+    if (this->context_->rank == srcRank_) {
+      for (int i = 0; i < niters; i++) {
+        buf_->send(dstRank_, kSlot);
+        // If we run synchronously, call waitSend after each send
+        if (!async_) {
+          buf_->waitSend();
+        }
+      }
+      // If we run asynchronously, call waitSend after all sends
+      if (async_) {
+        for (int i = 0; i < niters; i++) {
+          buf_->waitSend();
+        }
+      }
+    // Only recv on process with rank 1
+    } else {
+      for (int i = 0; i < niters; i++) {
+        buf_->recv(srcRank_, kSlot);
+        // If we run synchronously, call waitRecv after each recv
+        if (!async_) {
+          buf_->waitRecv();
+        }
+      }
+      // If we run asynchronously, call waitRecv after all recvs
+      if (async_) {
+        for (int i = 0; i < niters; i++) {
+          buf_->waitRecv();
+        }
+      }
+    }
+  }
+
+  void verify() override {
+    // Only verify for rank that actually got sent data
+    if (this->context_->rank == dstRank_) {
+      // Stride is the total number of
+      // pointers across the context
+      auto stride = this->context_->size * this->inputs_.size();
+      for (const auto& input : this->inputs_) {
+        for (int i = 0; i < input.size(); i++) {
+          auto offset = i * stride;
+          // Input should match the values from sender
+          GLOO_ENFORCE_EQ(
+            T(offset + srcRank_), input[i],
+            kMismatchErrorString, i);
+        }
+      }
+    }
+  }
+
+ protected:
+  std::unique_ptr<transport::UnboundBuffer> buf_;
+  // Always send from rank 0 and receive from rank 1
+  const int srcRank_ = 0;
+  const int dstRank_ = 1;
+  // Whether to send/recv asynchronously or not
+  const bool async_;
+};
+
 } // namespace
 
 // Namespace for the new style algorithm benchmarks.
@@ -892,6 +974,20 @@ class NewAllreduceBenchmark : public Benchmark<T> {
       kNumProcessesErrorString, x.contextSize);                            \
     fn = [&](std::shared_ptr<Context>& context) {                          \
       return gloo::make_unique<SendRecvRoundtripBenchmark<T>>(context, x); \
+    };                                                                     \
+  } else if (x.benchmark == "sendrecv_stress") {                           \
+    GLOO_ENFORCE_EQ(x.contextSize, kSendRecvProcesses,                     \
+      kNumProcessesErrorString, x.contextSize);                            \
+    fn = [&](std::shared_ptr<Context>& context) {                          \
+      return gloo::make_unique<                                            \
+          SendRecvStressBenchmark<T>>(context, x, false);                  \
+    };                                                                     \
+  } else if (x.benchmark == "isendirecv_stress") {                         \
+    GLOO_ENFORCE_EQ(x.contextSize, kSendRecvProcesses,                     \
+      kNumProcessesErrorString, x.contextSize);                            \
+    fn = [&](std::shared_ptr<Context>& context) {                          \
+      return gloo::make_unique<                                            \
+          SendRecvStressBenchmark<T>>(context, x, true);                   \
     };                                                                     \
   }                                                                        \
   if (!fn) {                                                               \

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -30,7 +30,7 @@ static void usage(int status, const char* argv0) {
   X("");
   X("Participation:");
   X("  -s, --size=SIZE        Number of processes");
-  X("                         Note: Need exactly two processes for sendrecv benchmarks");
+  X("                         Note: Need exactly two processes for send/recv benchmarks");
   X("  -r, --rank=RANK        Rank of this process");
   X("");
   X("Rendezvous:");
@@ -75,7 +75,9 @@ static void usage(int status, const char* argv0) {
   X("      --destinations     Number of separate destinations per host in "
                               "pairwise exchange benchmark");
   X("Algorithm parameters:");
-  X("      --base   The base for allreduce_bcube (if applicable)");
+  X("      --base           The base for allreduce_bcube (if applicable)");
+  X("      --messages       The number of messages to send from A to B for");
+  X("                       sendrecv_stress and isendirecv_stress (default: 10000)");
   X("");
   X("BENCHMARK is one of:");
   X("  allgather");
@@ -96,6 +98,8 @@ static void usage(int status, const char* argv0) {
   X("  reduce_scatter");
   X("  scatter");
   X("  sendrecv_roundtrip");
+  X("  sendrecv_stress");
+  X("  isendirecv_stress");
   X("");
 
   exit(status);
@@ -164,6 +168,7 @@ struct options parseOptions(int argc, char** argv) {
       {"ib-port", required_argument, nullptr, 0x100f},
       {"tcp-device", required_argument, nullptr, 0x1010},
       {"base", required_argument, nullptr, 0x1011},
+      {"messages", required_argument, nullptr, 0x1013},
       {"pkey", required_argument, nullptr, 0x2001},
       {"cert", required_argument, nullptr, 0x2002},
       {"ca-file", required_argument, nullptr, 0x2003},
@@ -298,6 +303,11 @@ struct options parseOptions(int argc, char** argv) {
       case 0x1012: // --shared-path
       {
         result.sharedPath = std::string(optarg, strlen(optarg));
+        break;
+      }
+      case 0x1013: // --messages
+      {
+        result.messages = atoi(optarg);
         break;
       }
       case 0x2001: // --pkey

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -30,6 +30,7 @@ static void usage(int status, const char* argv0) {
   X("");
   X("Participation:");
   X("  -s, --size=SIZE        Number of processes");
+  X("                         Note: Need exactly two processes for sendrecv benchmarks");
   X("  -r, --rank=RANK        Rank of this process");
   X("");
   X("Rendezvous:");
@@ -94,6 +95,7 @@ static void usage(int status, const char* argv0) {
   X("  reduce");
   X("  reduce_scatter");
   X("  scatter");
+  X("  sendrecv_roundtrip");
   X("");
 
   exit(status);

--- a/gloo/benchmark/options.h
+++ b/gloo/benchmark/options.h
@@ -56,6 +56,7 @@ struct options {
   int destinations  = 1;
   int threads = 1;
   int base = 2;
+  int messages = 10000;
 
   // TLS
   std::string pkey;


### PR DESCRIPTION
Summary:
**This diff:**
- adds a benchmark for send/recv and isend/irecv where it sends 1000 messages of size element
- updated `--help` to reflect new benchmark
- added new command line option `--messages` to set number of messages to send (default: 1000)

**This stack:**
The purpose of this stack is to add support for various benchmarks for p2p communications (send/recv/isend/irecv)

Differential Revision: D26265967

