### PR TITLE
Add benchmarking support for p2p communications (alternating msg size)

### DIFF
--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -75,7 +75,9 @@ static void usage(int status, const char* argv0) {
   X("      --destinations     Number of separate destinations per host in "
                               "pairwise exchange benchmark");
   X("Algorithm parameters:");
-  X("      --base   The base for allreduce_bcube (if applicable)");
+  X("      --base           The base for allreduce_bcube (if applicable)");
+  X("      --messages       The number of messages to send from A to B for");
+  X("                       sendrecv_stress and isendirecv_stress (default: 1000)");
   X("");
   X("BENCHMARK is one of:");
   X("  allgather");
@@ -96,6 +98,8 @@ static void usage(int status, const char* argv0) {
   X("  reduce_scatter");
   X("  scatter");
   X("  sendrecv_roundtrip");
+  X("  sendrecv_stress");
+  X("  isendirecv_stress");
   X("");
 
   exit(status);
@@ -164,6 +168,7 @@ struct options parseOptions(int argc, char** argv) {
       {"ib-port", required_argument, nullptr, 0x100f},
       {"tcp-device", required_argument, nullptr, 0x1010},
       {"base", required_argument, nullptr, 0x1011},
+      {"messages", required_argument, nullptr, 0x1013},
       {"pkey", required_argument, nullptr, 0x2001},
       {"cert", required_argument, nullptr, 0x2002},
       {"ca-file", required_argument, nullptr, 0x2003},
@@ -298,6 +303,11 @@ struct options parseOptions(int argc, char** argv) {
       case 0x1012: // --shared-path
       {
         result.sharedPath = std::string(optarg, strlen(optarg));
+        break;
+      }
+      case 0x1013: // --messages
+      {
+        result.messages = atoi(optarg);
         break;
       }
       case 0x2001: // --pkey

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -77,7 +77,8 @@ static void usage(int status, const char* argv0) {
   X("Algorithm parameters:");
   X("      --base           The base for allreduce_bcube (if applicable)");
   X("      --messages       The number of messages to send from A to B for");
-  X("                       sendrecv_stress and isendirecv_stress (default: 1000)");
+  X("                       sendrecv_stress, isendirecv_stress, sendrecv_alt,");
+  X("                       and isendirecv_alt (default: 1000)");
   X("");
   X("BENCHMARK is one of:");
   X("  allgather");
@@ -100,6 +101,8 @@ static void usage(int status, const char* argv0) {
   X("  sendrecv_roundtrip");
   X("  sendrecv_stress");
   X("  isendirecv_stress");
+  X("  sendrecv_alt");
+  X("  isendirecv_alt");
   X("");
 
   exit(status);

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -30,6 +30,7 @@ static void usage(int status, const char* argv0) {
   X("");
   X("Participation:");
   X("  -s, --size=SIZE        Number of processes");
+  X("                         Note: Need exactly two processes for sendrecv benchmarks");
   X("  -r, --rank=RANK        Rank of this process");
   X("");
   X("Rendezvous:");
@@ -94,6 +95,7 @@ static void usage(int status, const char* argv0) {
   X("  reduce");
   X("  reduce_scatter");
   X("  scatter");
+  X("  sendrecv_roundtrip");
   X("");
 
   exit(status);

--- a/gloo/benchmark/options.h
+++ b/gloo/benchmark/options.h
@@ -56,6 +56,7 @@ struct options {
   int destinations  = 1;
   int threads = 1;
   int base = 2;
+  int messages = 1000;
 
   // TLS
   std::string pkey;


### PR DESCRIPTION
Summary:
**This diff:**
The purpose of this diff is to add benchmarks for send/recv and isend/irecv where it sends many messages of alternating size (large and small)

Since the code is very similar for this benchmark and the existing benchmark SendRecvStressBenchmark, I modified the existing class to have the extra option to alternate message sizes when sending (rather than creating a whole new class).

Also updated the `--help` to reflect these new benchmarks.

**This stack:**
The purpose of this stack is to add support for various benchmarks for p2p communications (send/recv/isend/irecv)

Differential Revision: D26316098

