### PR TITLE
update bandwidth measurement

### DIFF
--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -67,6 +67,7 @@ static void usage(int status, const char* argv0) {
   X("      --inputs           Number of input buffers");
   X("      --elements         Number of floats to use per input buffer");
   X("      --iteration-count  Number of iterations to run benchmark for");
+  X("                         Iteration time is used instead if not specified");
   X("      --iteration-time   Time to run benchmark for (default: 2s)");
   X("      --threads          Number of threads to spawn (default: 1)");
   X("      --nanos            Display timing data in nanos instead of micros");

--- a/gloo/benchmark/runner.h
+++ b/gloo/benchmark/runner.h
@@ -100,6 +100,12 @@ class Runner {
   template <typename T>
   void run(BenchmarkFn<T>& fn, size_t n);
 
+  template <typename T>
+  Samples createAndRun(
+    std::vector<std::unique_ptr<Benchmark<T>>> &benchmarks,
+    int niters
+  );
+
  protected:
 #if GLOO_USE_REDIS
   void rendezvousRedis();


### PR DESCRIPTION
Summary:
The purpose of this diff is to clean up the bandwidth measurement code for the gloo benchmark. The current benchmark already implements the bandwidth measurement, however some parts of the code are repetitive and some are unclear/not documented well.

**Changes:**
- Refactor bandwidth measurement calculation slightly + add more comments
- Add extra barrier call after benchmark is run
- Rename output column from 'avg' to 'bw'
- Extract running the jobs into a separate function `createAndRun` to be used for both the warmup and actual runs
- Update logic for warmup iterations so that it is being run even if the user specifies the number of iterations (currently does not get run if the user uses iteration-count option)
- Add comments to clarify how iteration-count is obtained when not specified

Differential Revision: D26587250

