### PR TITLE
Fix bug triggered by libuv v1.41 on Linux

### DIFF
--- a/gloo/transport/uv/libuv.h
+++ b/gloo/transport/uv/libuv.h
@@ -598,26 +598,20 @@ class TCP final : public Handle<TCP, uv_tcp_t> {
 
   void read(char* ptr, size_t length) {
     reads_.emplace_back(ptr, length);
-    auto rv = uv_read_start(
-        this->template get<uv_stream_t>(), &uv__alloc_cb, &uv__read_cb);
-#ifdef _WIN32
-    if(rv == UV_EALREADY) {
-      return;
+    if (reads_.size() == 1) {
+      auto rv = uv_read_start(
+          this->template get<uv_stream_t>(), &uv__alloc_cb, &uv__read_cb);
+      UV_ASSERT(rv, "uv_read_start");
     }
-#endif
-    UV_ASSERT(rv, "uv_read_start");
   }
 
   void read(std::unique_ptr<char[]> buf, size_t length) {
     reads_.emplace_back(std::move(buf), length);
-    auto rv =
-        uv_read_start(this->get<uv_stream_t>(), &uv__alloc_cb, &uv__read_cb);
-#ifdef _WIN32
-    if(rv == UV_EALREADY) {
-      return;
+    if (reads_.size() == 1) {
+      auto rv =
+          uv_read_start(this->get<uv_stream_t>(), &uv__alloc_cb, &uv__read_cb);
+      UV_ASSERT(rv, "uv_read_start");
     }
-#endif
-    UV_ASSERT(rv, "uv_read_start");
   }
 
   void write(char* ptr, size_t length) {


### PR DESCRIPTION
Summary:
The `uv_read_start` function puts a libuv handle in read mode. This used to be an idempotent function on Linux (calling it on an already-reading handle would have no effect), but in Windows it would return an error. In https://github.com/libuv/libuv/commit/06b731742208c0c7b0b56948da2f2e0c9e645ec9, libuv made the API consistent, by having it return an error on Linux too. This caused Gloo to throw on Linux when using a recent version of libuv (i.e., v1.41 or later).

Note that this bug was already encountered and fixed when Windows support was introduced in D23451784 (https://github.com/facebookincubator/gloo/commit/881f7f0dcf06f7e49e134a45d3284860fb244fa9), although that fix was guarded by `#ifdef _WIN32`. Here I'm introducing a different fix, which helps avoid that bad call rather than just silencing the error, and thus remove the discrepancy between Linux and Window and remove that `#ifdef`.

Differential Revision: D26607632

