### PR TITLE
Update gloo benchmark output

### DIFF
--- a/gloo/benchmark/benchmark.h
+++ b/gloo/benchmark/benchmark.h
@@ -39,7 +39,13 @@ class Benchmark {
     algorithm_->run();
   }
 
-  virtual void verify() {}
+  virtual void verify() {}  // Leaving this for cuda_main for now
+  virtual void verify(std::vector<std::string> &errors) {
+    // To temporarily silence clang warning
+    // TO-DO: implement missing verify functions so we can
+    //        change this to a pure virtual function (T85537432)
+    errors.clear();
+  }
 
   const options& getOptions() const {
     return options_;

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -63,7 +63,8 @@ static void usage(int status, const char* argv0) {
   X("      --ib-index=INDEX          InfiniBand index to use (default: 0)");
   X("");
   X("Benchmark parameters:");
-  X("      --verify           Verify result first iteration (if applicable)");
+  X("      --no-verify        Do not verify results of first iteration");
+  X("      --show-all-errors  Displays all errors when running with verify");
   X("      --inputs           Number of input buffers");
   X("      --elements         Number of floats to use per input buffer");
   X("      --warmup-iters     Number of warmup iterations to run (default: 5)");
@@ -154,7 +155,8 @@ struct options parseOptions(int argc, char** argv) {
       {"prefix", required_argument, nullptr, 'x'},
       {"shared-path", required_argument, nullptr, 0x1012},
       {"transport", required_argument, nullptr, 't'},
-      {"verify", no_argument, nullptr, 0x1001},
+      {"no-verify", no_argument, nullptr, 0x1001},
+      {"show-all-errors", no_argument, nullptr, 0x1015},
       {"elements", required_argument, nullptr, 0x1002},
       {"warmup-iters", required_argument, nullptr, 0x1014},
       {"iteration-count", required_argument, nullptr, 0x1003},
@@ -213,9 +215,14 @@ struct options parseOptions(int argc, char** argv) {
         result.transport = std::string(optarg, strlen(optarg));
         break;
       }
-      case 0x1001: // --verify
+      case 0x1001: // --no-verify
       {
-        result.verify = true;
+        result.verify = false;
+        break;
+      }
+      case 0x1015: // --show-all-errors
+      {
+        result.showAllErrors = true;
         break;
       }
       case 0x1002: // --elements

--- a/gloo/benchmark/options.h
+++ b/gloo/benchmark/options.h
@@ -44,7 +44,8 @@ struct options {
 
   // Suite configuration
   std::string benchmark;
-  bool verify = false;
+  bool verify = true;
+  bool showAllErrors = false;
   int elements = -1;
   long iterationCount = -1;
   long minIterationTimeNanos = 2 * 1000 * 1000 * 1000;

--- a/gloo/benchmark/runner.h
+++ b/gloo/benchmark/runner.h
@@ -126,6 +126,12 @@ class Runner {
       size_t elements,
       size_t elementSize,
       const Distribution& samples);
+  void printVerifyHeader();
+  void printFooter();
+
+  // Checks and prints errors, exits the program with
+  // status 1 if any errors were found
+  void checkErrors();
 
   options options_;
   std::vector<std::shared_ptr<transport::Device>> transportDevices_;
@@ -135,6 +141,8 @@ class Runner {
   long broadcastValue_;
   std::unique_ptr<Algorithm> broadcast_;
   std::unique_ptr<Barrier> barrier_;
+
+  std::vector<std::string> mismatchErrors_;
 };
 
 } // namespace benchmark


### PR DESCRIPTION
Summary:
The purpose of this diff is to update how errors are displayed during correctness verification.

Originally, the benchmark would exit right away once it detects a mismatch. This diff changes this so that the currently running benchmark is now run to completion and mismatches are only displayed at the very end.

If a user does not specify element size, the benchmark by default will do a sweep of numbers ranging from 100 to 5000000. In this case, the benchmark will stop the next sweep at the first instance of a mismatch (but will still run current one to completion). See test plan for example.

Change Summary:
- Refactor out a common verify pattern into a new function `constStrideVerify` where there is a constant stride between elements in the array
- Add new errorMsg parameter to the verify function which will catch all error messages generated to print at the end
- Add new class function `printMismatches` that outputs the mismatches
- Break output into more readable sections by printing headers

Differential Revision: D26637016

