### PR TITLE
Add support for minimum run time when using benchmark

### DIFF
--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -66,9 +66,11 @@ static void usage(int status, const char* argv0) {
   X("      --verify           Verify result first iteration (if applicable)");
   X("      --inputs           Number of input buffers");
   X("      --elements         Number of floats to use per input buffer");
+  X("      --warmup-iters     Number of warmup iterations to run (default: 5)");
   X("      --iteration-count  Number of iterations to run benchmark for");
-  X("                         Iteration time is used instead if not specified");
-  X("      --iteration-time   Time to run benchmark for (default: 2s)");
+  X("                         Iteration time is used by default if not specified");
+  X("      --iteration-time   Minimum time to run benchmark for (default: 2s)");
+  X("                         This value is unused if iteration count is specified");
   X("      --threads          Number of threads to spawn (default: 1)");
   X("      --nanos            Display timing data in nanos instead of micros");
   X("      --gpudirect        Use GPUDirect (CUDA only)");
@@ -154,6 +156,7 @@ struct options parseOptions(int argc, char** argv) {
       {"transport", required_argument, nullptr, 't'},
       {"verify", no_argument, nullptr, 0x1001},
       {"elements", required_argument, nullptr, 0x1002},
+      {"warmup-iters", required_argument, nullptr, 0x1014},
       {"iteration-count", required_argument, nullptr, 0x1003},
       {"iteration-time", required_argument, nullptr, 0x1004},
       {"sync", required_argument, nullptr, 0x1005},
@@ -220,6 +223,11 @@ struct options parseOptions(int argc, char** argv) {
         result.elements = atoi(optarg);
         break;
       }
+      case 0x1014: // --warmup-iters
+      {
+        result.warmupIterationCount = atoi(optarg);
+        break;
+      }
       case 0x1003: // --iteration-count
       {
         result.iterationCount = atoi(optarg);
@@ -227,7 +235,7 @@ struct options parseOptions(int argc, char** argv) {
       }
       case 0x1004: // --iteration-time
       {
-        result.iterationTimeNanos = argToNanos(argv, optarg);
+        result.minIterationTimeNanos = argToNanos(argv, optarg);
         break;
       }
       case 0x1005: // --sync

--- a/gloo/benchmark/options.h
+++ b/gloo/benchmark/options.h
@@ -47,7 +47,7 @@ struct options {
   bool verify = false;
   int elements = -1;
   long iterationCount = -1;
-  long iterationTimeNanos = 2 * 1000 * 1000 * 1000;
+  long minIterationTimeNanos = 2 * 1000 * 1000 * 1000;
   int warmupIterationCount = 5;
   bool showNanos = false;
   int inputs = 1;

--- a/gloo/benchmark/timer.h
+++ b/gloo/benchmark/timer.h
@@ -59,6 +59,14 @@ public:
       other.samples_.end());
   }
 
+  long sum() const {
+    long result = 0;
+    for (auto& sample : samples_) {
+      result += sample;
+    }
+    return result;
+  }
+
  protected:
   std::vector<long> samples_;
 


### PR DESCRIPTION
Summary:
The purpose of this diff is to add an option for minimum run time when running the benchmark. Currently, when iteration count is not specified, the benchmark takes the `iterationTimeNanos` and divides it by the median time spent during warmup runs to get an estimate of the number of iterations. The user is able to specify the `iterationTimeNanos` but the benchmark does not actually run for that long.

Instead, we want the user to be able to specify the minimum time that the benchmark runs for.

Referenced Google's Benchmark: https://github.com/google/benchmark/blob/5c43112eb3d70cec10784d8d1f4373bc7397836b/src/benchmark_runner.cc#L252

Changes:
- Add new loop logic so that benchmark will re-run with increased iteration count if total time spent is less than the specified amount
- Add new class function `Samples::sum` so we can get total sum without having to sort first using `Distribution` class
- Add warmup iterations as an option for the user to specify
- Rename iterationTimeNanos to minIterationTimeNanos to be more clear
- Clarify the usage of certain options in `--help`
- Add max number of iterations (constant) when running for a specified amount of time

Differential Revision: D26644215

