### PR TITLE
Automatically delete rendezvous files after a run

### DIFF
--- a/gloo/benchmark/main.cc
+++ b/gloo/benchmark/main.cc
@@ -40,13 +40,6 @@
 using namespace gloo;
 using namespace gloo::benchmark;
 
-// NOTE:
-// Before running the benchmark, ensure that previously
-// generated rendezvous files have been deleted.
-// Rendezvous files are saved in the path specified
-// by the --shared-path option and have names
-// consisting of only numbers.
-
 namespace {
 
 // constant offset used for alltoall when populating input data

--- a/gloo/benchmark/options.cc
+++ b/gloo/benchmark/options.cc
@@ -38,8 +38,6 @@ static void usage(int status, const char* argv0) {
   X("  -p, --redis-port=PORT  Port number of Redis server");
   X("  -x, --prefix=PREFIX    Rendezvous prefix (unique for this run)");
   X("      --shared-path=PATH File system rendezvous with this shared path");
-  X("                         Note: delete previously generated rendezvous");
-  X("                               files in this path before running benchmark");
   X("");
   X("Transport:");
   X("  -t, --transport=TRANSPORT Transport to use (tcp, ibverbs, ...)");

--- a/gloo/benchmark/runner.h
+++ b/gloo/benchmark/runner.h
@@ -136,6 +136,7 @@ class Runner {
   options options_;
   std::vector<std::shared_ptr<transport::Device>> transportDevices_;
   std::shared_ptr<rendezvous::ContextFactory> contextFactory_;
+  std::vector<std::string> keyFilePaths_;
   std::vector<std::unique_ptr<RunnerThread>> threads_;
 
   long broadcastValue_;

--- a/gloo/rendezvous/file_store.cc
+++ b/gloo/rendezvous/file_store.cc
@@ -65,6 +65,9 @@ void FileStore::set(const std::string& key, const std::vector<char>& data) {
   auto tmp = tmpPath(key);
   auto path = objectPath(key);
 
+  // Save file path
+  keyFilePaths_.emplace_back(path);
+
   {
     // Fail if the key already exists. This implementation is not race free.
     // A race free solution would need to atomically create the file 'path'
@@ -147,6 +150,10 @@ void FileStore::wait(
     /* sleep override */
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
+}
+
+std::vector<std::string> FileStore::getAllKeyFilePaths() {
+  return keyFilePaths_;
 }
 
 } // namespace rendezvous

--- a/gloo/rendezvous/file_store.h
+++ b/gloo/rendezvous/file_store.h
@@ -34,6 +34,8 @@ class FileStore : public Store {
       const std::vector<std::string>& keys,
       const std::chrono::milliseconds& timeout) override;
 
+  std::vector<std::string> getAllKeyFilePaths();
+
  protected:
   std::string basePath_;
 
@@ -44,6 +46,8 @@ class FileStore : public Store {
   std::string objectPath(const std::string& name);
 
   bool check(const std::vector<std::string>& keys);
+
+  std::vector<std::string> keyFilePaths_;
 };
 
 } // namespace rendezvous


### PR DESCRIPTION
Summary:
The purpose of this diff is to automatically delete rendezvous files after the benchmark is done running. This way, the user does not have to manually delete the files in order to run the benchmark again. This is only relevant when the user uses `FileStore` to rendezvous (not Redis or MPI).

`FileStore::set` takes in a key and generates a file based on the hash of this key. Added a new class variable `FileStore::rdzvFilePaths` which will store these paths. After calling `Context::connectFullMesh`, these paths will have been generated and we can call `FileStore::getRdzvFilePaths` to get the paths to delete at the end of the run.

Change Summary:
- Remove comments about deleting files
- Add `rdzvFilePaths_` to `Runner`
- Add `rdzvFilePaths` and `getRdzvFilePaths` to `FileStore`

Differential Revision: D27028023

