### PR TITLE
Fix race condition in gloo

### DIFF
--- a/gloo/transport/tcp/address.h
+++ b/gloo/transport/tcp/address.h
@@ -10,6 +10,7 @@
 
 #include <sys/socket.h>
 #include <unistd.h>
+#include <mutex>
 
 #include "gloo/transport/address.h"
 
@@ -30,6 +31,11 @@ class Address : public ::gloo::transport::Address {
   explicit Address(const struct sockaddr* addr, size_t addrlen);
 
   explicit Address(const std::vector<char>&);
+
+  Address(const Address& other);
+
+  Address& operator=(Address&& other);
+  Address& operator=(const Address& other);
 
   virtual std::vector<char> bytes() const override;
 
@@ -65,6 +71,7 @@ class Address : public ::gloo::transport::Address {
   static_assert(sizeof(Impl) <= kMaxByteSize, "!");
 
   Impl impl_;
+  mutable std::mutex m_;
 };
 
 } // namespace tcp

--- a/gloo/transport/uv/address.cc
+++ b/gloo/transport/uv/address.cc
@@ -28,10 +28,28 @@ Address::Address(const std::vector<char>& bytes) {
   memcpy(&impl_, bytes.data(), sizeof(impl_));
 }
 
+Address::Address(const Address& other)
+    : Address(other.impl_.ss, other.impl_.seq) {}
+
 std::vector<char> Address::bytes() const {
+  std::lock_guard<std::mutex> lock(m_);
   std::vector<char> bytes(sizeof(impl_));
   memcpy(bytes.data(), &impl_, sizeof(impl_));
   return bytes;
+}
+
+Address& Address::operator=(Address&& other) {
+  std::lock_guard<std::mutex> lock(m_);
+  impl_.ss = std::move(other.impl_.ss);
+  impl_.seq = other.impl_.seq;
+  return *this;
+}
+
+Address& Address::operator=(const Address& other) {
+  std::lock_guard<std::mutex> lock(m_);
+  impl_.ss = other.impl_.ss;
+  impl_.seq = other.impl_.seq;
+  return *this;
 }
 
 std::string Address::str() const {

--- a/gloo/transport/uv/address.h
+++ b/gloo/transport/uv/address.h
@@ -14,6 +14,8 @@
 #include <sys/socket.h>
 #endif
 
+#include <mutex>
+
 #include <gloo/transport/address.h>
 
 namespace gloo {
@@ -29,6 +31,10 @@ class Address : public ::gloo::transport::Address {
   Address(struct sockaddr_storage ss, sequence_type seq = -1);
 
   explicit Address(const std::vector<char>&);
+
+  Address& operator=(Address&& other);
+  Address& operator=(const Address& other);
+  Address(const Address& other);
 
   virtual std::vector<char> bytes() const override;
 
@@ -63,6 +69,7 @@ class Address : public ::gloo::transport::Address {
   static_assert(std::is_trivially_copyable<Impl>::value, "!");
 
   Impl impl_;
+  mutable std::mutex m_;
 };
 
 } // namespace uv


### PR DESCRIPTION
Summary:
Nearly all TSAN rpc tests are failing, see: https://fburl.com/tests/od9jrvzm

This diff resolves one of the race conditions that is very frequently, see error: P413340057. There are still some other race conditions in e.g. autograd that we can look into separately. For autograd, one test that reproduces the race condition is `test_backward_ddp_outside`.

At a high level, the issue was concurrent access to `gloo::transport::Address` that tsan identified as a data race. Verified that the TSAN tests pass now with this change.

Reviewed By: SciPioneer

Differential Revision: D28273572

