### PR TITLE
allow reduce and allreduce to accept size 0 input

### DIFF
--- a/gloo/allreduce.cc
+++ b/gloo/allreduce.cc
@@ -95,6 +95,10 @@ BroadcastRangeFunction genLocalBroadcastFunction(const BufferVector& out) {
 }
 
 void allreduce(const detail::AllreduceOptionsImpl& opts) {
+  if (opts.elements == 0) {
+    return;
+  }
+
   const auto& context = opts.context;
   const std::vector<std::unique_ptr<transport::UnboundBuffer>>& in = opts.in;
   const std::vector<std::unique_ptr<transport::UnboundBuffer>>& out = opts.out;
@@ -102,7 +106,6 @@ void allreduce(const detail::AllreduceOptionsImpl& opts) {
 
   // Sanity checks
   GLOO_ENFORCE_GT(out.size(), 0);
-  GLOO_ENFORCE(opts.elements > 0);
   GLOO_ENFORCE(opts.elementSize > 0);
   GLOO_ENFORCE(opts.reduce != nullptr);
 

--- a/gloo/allreduce_bcube.h
+++ b/gloo/allreduce_bcube.h
@@ -270,7 +270,7 @@ class AllreduceBcube : public Algorithm {
         steps_(computeSteps(nodes_, base_)),
         fn_(fn),
         recvBufs_(steps_ * base_) {
-    if (nodes_ == 1) {
+    if (totalNumElems_ == 0 || nodes_ == 1) {
       return;
     }
     setupNodes();
@@ -336,6 +336,9 @@ class AllreduceBcube : public Algorithm {
 #endif
 
   void run() {
+    if (totalNumElems_ == 0) {
+      return;
+    }
     // Local reduce operation
     for (int i = 1; i < ptrs_.size(); i++) {
       fn_->call(ptrs_[0], ptrs_[i], totalNumElems_);

--- a/gloo/allreduce_halving_doubling.h
+++ b/gloo/allreduce_halving_doubling.h
@@ -90,7 +90,7 @@ class AllreduceHalvingDoubling : public Algorithm {
         rankInBinaryBlock_(0),
         nextSmallerBlockSize_(0),
         nextLargerBlockSize_(0) {
-    if (this->contextSize_ == 1) {
+    if (count_ == 0 || this->contextSize_ == 1) {
         return;
     }
 
@@ -222,6 +222,9 @@ class AllreduceHalvingDoubling : public Algorithm {
   }
 
   void run() {
+    if (count_ == 0) {
+      return;
+    }
     size_t bufferOffset = 0;
     size_t numItems =
         stepsWithinBlock_ > 0 ? chunkSize_ << (steps_ - 1) : count_;

--- a/gloo/allreduce_ring.h
+++ b/gloo/allreduce_ring.h
@@ -67,6 +67,10 @@ class AllreduceRing : public Algorithm {
   }
 
   void run() {
+    if (count_ == 0) {
+      return;
+    }
+
     // Reduce specified pointers into ptrs_[0]
     for (int i = 1; i < ptrs_.size(); i++) {
       fn_->call(ptrs_[0], ptrs_[i], count_);

--- a/gloo/allreduce_ring_chunked.h
+++ b/gloo/allreduce_ring_chunked.h
@@ -44,7 +44,7 @@ class AllreduceRingChunked : public Algorithm {
       inbox_[i] = static_cast<T*>(malloc(bytes_));
     }
 
-    if (this->contextSize_ == 1) {
+    if (count_ == 0 || this->contextSize_ == 1) {
       return;
     }
 
@@ -81,6 +81,10 @@ class AllreduceRingChunked : public Algorithm {
   }
 
   void run() {
+    if (count_ == 0) {
+      return;
+    }
+
     // Reduce specified pointers into ptrs_[0]
     for (int i = 1; i < ptrs_.size(); i++) {
       fn_->call(ptrs_[0], ptrs_[i], count_);

--- a/gloo/reduce.cc
+++ b/gloo/reduce.cc
@@ -19,13 +19,15 @@
 namespace gloo {
 
 void reduce(ReduceOptions& opts) {
+  if (opts.elements == 0) {
+    return;
+  }
   const auto& context = opts.context;
   transport::UnboundBuffer* in = opts.in.get();
   transport::UnboundBuffer* out = opts.out.get();
   const auto slot = Slot::build(kReduceSlotPrefix, opts.tag);
 
   // Sanity checks
-  GLOO_ENFORCE(opts.elements > 0);
   GLOO_ENFORCE(opts.elementSize > 0);
   GLOO_ENFORCE(opts.root >= 0 && opts.root < context->size);
   GLOO_ENFORCE(opts.reduce != nullptr);

--- a/gloo/test/allreduce_test.cc
+++ b/gloo/test/allreduce_test.cc
@@ -244,7 +244,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::ValuesIn(kTransportsForClassAlgorithms),
         ::testing::Range(1, 16),
-        ::testing::Values(4, 100, 1000, 10000),
+        ::testing::Values(0, 4, 100, 1000, 10000),
         ::testing::Values(allreduceRing),
         ::testing::Values(0)));
 
@@ -254,7 +254,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::ValuesIn(kTransportsForClassAlgorithms),
         ::testing::Range(1, 16),
-        ::testing::Values(4, 100, 1000, 10000),
+        ::testing::Values(0, 4, 100, 1000, 10000),
         ::testing::Values(allreduceRingChunked),
         ::testing::Values(0)));
 
@@ -264,7 +264,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::ValuesIn(kTransportsForClassAlgorithms),
         ::testing::Values(1, 2, 3, 4, 5, 6, 7, 8, 9, 13, 16, 24, 32),
-        ::testing::Values(1, 64, 1000),
+        ::testing::Values(0, 1, 64, 1000),
         ::testing::Values(allreduceHalvingDoubling),
         ::testing::Values(0)));
 
@@ -274,7 +274,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::ValuesIn(kTransportsForClassAlgorithms),
         ::testing::Values(1, 2, 4, 8, 16),
-        ::testing::Values(1, 64, 1000),
+        ::testing::Values(0, 1, 64, 1000),
         ::testing::Values(allreduceBcube),
         ::testing::Values(2)));
 
@@ -284,7 +284,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::ValuesIn(kTransportsForClassAlgorithms),
         ::testing::Values(1, 3, 9, 27),
-        ::testing::Values(1, 64, 1000),
+        ::testing::Values(0, 1, 64, 1000),
         ::testing::Values(allreduceBcube),
         ::testing::Values(3)));
 
@@ -294,7 +294,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::ValuesIn(kTransportsForClassAlgorithms),
         ::testing::Values(1, 4, 16),
-        ::testing::Values(1, 64, 1000),
+        ::testing::Values(0, 1, 64, 1000),
         ::testing::Values(allreduceBcube),
         ::testing::Values(4)));
 
@@ -362,7 +362,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn(kTransportsForFunctionAlgorithms),
         ::testing::Values(1, 2, 4, 7),
         ::testing::Values(1, 2, 3),
-        ::testing::Values(1, 10, 100, 1000, 10000),
+        ::testing::Values(0, 1, 10, 100, 1000, 10000),
         ::testing::Values(true, false),
         ::testing::Values(Algorithm::RING)));
 
@@ -373,7 +373,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn(kTransportsForFunctionAlgorithms),
         ::testing::Values(1, 2, 4, 7),
         ::testing::Values(1, 2, 3),
-        ::testing::Values(1, 10, 100, 1000, 10000),
+        ::testing::Values(0, 1, 10, 100, 1000, 10000),
         ::testing::Values(true, false),
         ::testing::Values(Algorithm::BCUBE)));
 

--- a/gloo/test/reduce_test.cc
+++ b/gloo/test/reduce_test.cc
@@ -85,7 +85,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::ValuesIn(kTransportsForFunctionAlgorithms),
         ::testing::Values(1, 2, 4, 7),
-        ::testing::Values(1, 10, 100, 1000, 10000),
+        ::testing::Values(0, 1, 10, 100, 1000, 10000),
         ::testing::Values(true, false)));
 
 template <typename T>


### PR DESCRIPTION
Summary:
Context: https://github.com/pytorch/pytorch/issues/58467

We'd like GLOO to be conform with other backends and therefore it should accept 0 size input for reduce/allreduce.

Differential Revision: D28608970

