### PR TITLE
Fix an execution error in the sample code

### DIFF
--- a/gloo/examples/example1.cc
+++ b/gloo/examples/example1.cc
@@ -136,5 +136,16 @@ int main(void) {
     std::cout << "data[" << i << "] = " << data[i] << std::endl;
   }
 
+  // Automatically delete rendezvous files after
+  // this program is done running (if applicable)
+  auto keyFilePaths_ = fileStore.getAllKeyFilePaths();
+  for (auto path : keyFilePaths_) {
+    if (remove(path.c_str()) != 0) {
+      std::cout << "Failed to delete rendezvous file at " << path;
+      std::cout << " please delete manually before running this program again.";
+      std::cout << std::endl;
+    }
+  }
+
   return 0;
 }


### PR DESCRIPTION
The Gloo example code has a problem that it leaves the temporary file generated under tmp in previous execution. That file generate an error in next execution. Therefore, I create a code to erase it before exiting.