### PR TITLE
Fix TSAN issue in gloo

### DIFF
--- a/gloo/common/linux.cc
+++ b/gloo/common/linux.cc
@@ -153,6 +153,7 @@ int pciDistance(const std::string& a, const std::string& b) {
 const std::string& interfaceToBusID(const std::string& name) {
   static std::once_flag once;
   static std::map<std::string, std::string> map;
+  static std::string default_busid;
 
   std::call_once(once, [](){
       for (const auto& device : pciDevices(kPCIClassNetwork)) {
@@ -164,7 +165,11 @@ const std::string& interfaceToBusID(const std::string& name) {
       }
     });
 
-  return map[name];
+  auto it = map.find(name);
+  if (it != map.end()) {
+    return it->second;
+  }
+  return default_busid;
 }
 
 const std::string& infinibandToBusID(const std::string& name) {


### PR DESCRIPTION
Summary:
The previous code was using `return map[name]`, which on the surface
seems like a read operation. However, std::map's `[]` operator would write a
default constructed value to the map if `name` was not found. This resulted in
concurrent unexpected write requests.

To resolve this issue, changed the logic to be read-only.

Differential Revision: D32938695

