### PR TITLE
Fix build with clang and LLVM

### DIFF
--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -12,6 +12,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <string.h>
+#include <array>
 
 #include "gloo/common/linux.h"
 #include "gloo/common/logging.h"


### PR DESCRIPTION
Tested with LLVM 12.0.0
If archive is not included you will get following error:

```
external/gloo/gloo/transport/tcp/device.cc:151:39: error: implicit instantiation of undefined template 'std::array<char, 64>'
      std::array<char, HOST_NAME_MAX> hostname;
```