### PR TITLE
Fix some legacy hipify script

### DIFF
--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -1,13 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import, division, print_function
 
 import argparse
 import os
-import subprocess
-import sys
-from functools import reduce
-from itertools import chain
 
 from pyHIPIFY import hipify_python
 

--- a/tools/amd_build/pyHIPIFY/hipify_python.py
+++ b/tools/amd_build/pyHIPIFY/hipify_python.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ The Python Hipify script.
 ##
 # Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
@@ -27,11 +27,8 @@
 from __future__ import absolute_import, division, print_function
 
 import fnmatch
-import json
 import os
 import re
-import shutil
-import sys
 
 from pyHIPIFY.cuda_to_hip_mappings import CUDA_TO_HIP_MAPPINGS
 


### PR DESCRIPTION
Summary:
Fix some out-dated hipify script:
* python -> python3 (fb internal)
* rocblas return code
* gloo makefile for hip clang

Differential Revision: D33402839

