### PR TITLE
Fix TSAN issue in gloo shutdown.

### DIFF
--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -251,8 +251,8 @@ void Device::registerDescriptor(int fd, int events, Handler* h) {
   loop_->registerDescriptor(fd, events, h);
 }
 
-void Device::unregisterDescriptor(int fd) {
-  loop_->unregisterDescriptor(fd);
+void Device::unregisterDescriptor(int fd, Handler* h) {
+  loop_->unregisterDescriptor(fd, h);
 }
 
 } // namespace tcp

--- a/gloo/transport/tcp/device.h
+++ b/gloo/transport/tcp/device.h
@@ -47,7 +47,7 @@ class Device : public ::gloo::transport::Device,
       int rank, int size) override;
 
   void registerDescriptor(int fd, int events, Handler* h);
-  void unregisterDescriptor(int fd);
+  void unregisterDescriptor(int fd, Handler* h);
 
  protected:
   const struct attr attr_;

--- a/gloo/transport/tcp/loop.h
+++ b/gloo/transport/tcp/loop.h
@@ -40,7 +40,7 @@ class Loop final : public std::enable_shared_from_this<Loop> {
 
   void registerDescriptor(int fd, int events, Handler* h);
 
-  void unregisterDescriptor(int fd);
+  void unregisterDescriptor(int fd, Handler *h);
 
   void run();
 

--- a/gloo/transport/tcp/pair.cc
+++ b/gloo/transport/tcp/pair.cc
@@ -132,7 +132,7 @@ void Pair::setSync(bool sync, bool busyPoll) {
 
   if (!sync_) {
     // If async, unregister from loop and switch socket to blocking mode
-    device_->unregisterDescriptor(fd_);
+    device_->unregisterDescriptor(fd_, this);
     setSocketBlocking(fd_, true);
 
     // If the pair was still flushing writes, finish them.
@@ -245,7 +245,7 @@ void Pair::connect(const Address& peer) {
 
   // self_ > peer_; we are connecting side.
   // First destroy listening socket.
-  device_->unregisterDescriptor(fd_);
+  device_->unregisterDescriptor(fd_, this);
   ::close(fd_);
 
   // Create new socket to connect to peer.
@@ -770,7 +770,7 @@ void Pair::handleListening() {
 
   // Close the listening file descriptor whether we've successfully connected
   // or run into an error and will throw an exception.
-  device_->unregisterDescriptor(fd_);
+  device_->unregisterDescriptor(fd_, this);
   ::close(fd_);
   fd_ = FD_INVALID;
 
@@ -882,7 +882,7 @@ void Pair::changeState(state nextState) noexcept {
       case LISTENING:
         // The pair may be in the LISTENING state when it is destructed.
         if (fd_ != FD_INVALID) {
-          device_->unregisterDescriptor(fd_);
+          device_->unregisterDescriptor(fd_, this);
           ::close(fd_);
           fd_ = FD_INVALID;
         }
@@ -890,14 +890,14 @@ void Pair::changeState(state nextState) noexcept {
       case CONNECTING:
         // The pair may be in the CONNECTING state when it is destructed.
         if (fd_ != FD_INVALID) {
-          device_->unregisterDescriptor(fd_);
+          device_->unregisterDescriptor(fd_, this);
           ::close(fd_);
           fd_ = FD_INVALID;
         }
         break;
       case CONNECTED:
         if (!sync_) {
-          device_->unregisterDescriptor(fd_);
+          device_->unregisterDescriptor(fd_, this);
         }
         ::close(fd_);
         fd_ = FD_INVALID;


### PR DESCRIPTION
Summary:
The problem arose from the fact that Loop::run() would have raw
pointers to Pair objects (Handler). As a result, as part of the destruction of
the process group the Pair would get destroyed whereas the loop would still try
to access these destroyed objects via a raw pointer.

To fix the issue, we now ensure the pairs are appropriately closed and the
device loop is stopped before any objects are destroyed.

Differential Revision: D34665049

