### PR TITLE
fix hipified source path

### DIFF
--- a/gloo/nccl/CMakeLists.txt
+++ b/gloo/nccl/CMakeLists.txt
@@ -15,11 +15,11 @@ endif()
 
 if(USE_ROCM)
     set(GLOO_NCCL_SRCS
-      "${CMAKE_CURRENT_SOURCE_DIR}/nccl.hip"
+      "${HIPIFY_OUTPUT_DIR}/nccl/nccl.hip"
       )
 
     set(GLOO_NCCL_HDRS
-      "${CMAKE_CURRENT_SOURCE_DIR}/nccl.h"
+      "${HIPIFY_OUTPUT_DIR}/nccl/nccl.h"
       )
 
     list(APPEND GLOO_HIP_SRCS ${GLOO_NCCL_SRCS})


### PR DESCRIPTION
Summary:
At OSS gloo build time, all cu files are hipified by cmake for AMD build.
The hipified source files are in cmake build directory which can be different
from the original source path. Thus, we should always use HIPIFY_OUTPUT_DIR
rather than CMAKE_CURRENT_SOURCE_DIR to include these files.

HIPIFY_OUTPUT_DIR is defined by Hipify.cmake.

This diff fixes failure captured by OSS pytorch when trying to update gloo commit hash: https://github.com/pytorch/pytorch/runs/6379162434?check_suite_focus=true

Particular error:
```
 *** No rule to make target '../third_party/gloo/gloo/nccl/nccl.hip', needed by 'third_party/gloo/gloo/CMakeFiles/gloo_hip.dir/nccl/gloo_hip_generated_nccl.hip.o'.  Stop.
```

Differential Revision: D36457504

