### PR TITLE
Add missing <array> header for transport/tcp/device.cc

### DIFF
--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <array>
+
 #include "gloo/transport/tcp/device.h"
 
 #include <ifaddrs.h>


### PR DESCRIPTION
Without this it gives this error while building PyTorch
../third_party/gloo/gloo/transport/tcp/device.cc:151:39: error: aggregate ‘std::array<char, 64> hostname’ has incomplete type and cannot be defined
  151 |       std::array<char, HOST_NAME_MAX> hostname;
      |                                       ^~~~~~~~

Fixes https://github.com/facebookincubator/gloo/issues/332.