### PR TITLE
Fix build failure with clang-14

### DIFF
--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -12,6 +12,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <string.h>
+#include <array>
 
 #include "gloo/common/linux.h"
 #include "gloo/common/logging.h"


### PR DESCRIPTION
Need to explicitly include array header.