### PR TITLE
MinGW patches for cross-compilation

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -5,6 +5,10 @@ set(gloo_hip_DEPENDENCY_LIBS "")
 # Configure path to modules (for find_package)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/Modules/")
 
+if (WIN32)
+  list(APPEND gloo_DEPENDENCY_LIBS "ws2_32")
+endif()
+
 if(USE_REDIS)
   find_package(hiredis REQUIRED)
   if(HIREDIS_FOUND)

--- a/gloo/rendezvous/file_store.cc
+++ b/gloo/rendezvous/file_store.cc
@@ -37,7 +37,7 @@ FileStore::FileStore(const std::string& path) {
 }
 
 std::string FileStore::realPath(const std::string& path) {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
   std::array<char, _MAX_PATH> buf;
   auto ret = _fullpath(buf.data(), path.c_str(), buf.size());
 #else

--- a/gloo/types.h
+++ b/gloo/types.h
@@ -30,7 +30,7 @@
 #include "gloo/common/common.h"
 
 #ifdef _WIN32
-#include <BaseTsd.h>
+#include <basetsd.h>
 typedef SSIZE_T ssize_t;
 #endif
 


### PR DESCRIPTION
These patches were necessary to cross-compile for mingw32.

Cf.
* https://github.com/JuliaPackaging/Yggdrasil/pull/4570
* https://github.com/JuliaPackaging/Yggdrasil/pull/4571
* https://github.com/JuliaPackaging/Yggdrasil/pull/5352