### PR TITLE
Enabled cross-compilation for musl on linux

### DIFF
--- a/gloo/common/linux.cc
+++ b/gloo/common/linux.cc
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -198,7 +199,7 @@ static int getInterfaceSpeedGLinkSettings(int sock, struct ifreq* ifr) {
   } ecmd;
   int rv;
 
-  ifr->ifr_data = (__caddr_t)&ecmd;
+  ifr->ifr_data = (caddr_t)&ecmd;
   memset(&ecmd, 0, sizeof(ecmd));
   ecmd.req.cmd = ETHTOOL_GLINKSETTINGS;
 
@@ -226,7 +227,7 @@ static int getInterfaceSpeedGSet(int sock, struct ifreq* ifr) {
   struct ethtool_cmd edata;
   int rv;
 
-  ifr->ifr_data = (__caddr_t)&edata;
+  ifr->ifr_data = (caddr_t)&edata;
   memset(&edata, 0, sizeof(edata));
   edata.cmd = ETHTOOL_GSET;
 


### PR DESCRIPTION
This patch was necessary to enable cross-compilation for *-linux-musl