### PR TITLE
Make `tcp/device.cc` compileable by gcc-12

### DIFF
--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -8,10 +8,12 @@
 
 #include "gloo/transport/tcp/device.h"
 
+#include <array>
 #include <ifaddrs.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <string.h>
+
 
 #include "gloo/common/linux.h"
 #include "gloo/common/logging.h"


### PR DESCRIPTION
Should fix https://github.com/pytorch/pytorch/issues/86542 one commit is updated on PyTorch side