### PR TITLE
Fixed the bug in gatherv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /build*
 *.pyc
+.vscode/
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(USE_RCCL_DEFAULT OFF)
 set(USE_LIBUV_DEFAULT OFF)
 set(USE_TCP_OPENSSL_LINK_DEFAULT OFF)
 set(USE_TCP_OPENSSL_LOAD_DEFAULT OFF)
+set(CMAKE_CXX_STANDARD 14)
 
 # Options
 option(USE_REDIS "Support using Redis for rendezvous" ${USE_REDIS_DEFAULT})
@@ -117,7 +118,7 @@ include_directories(${PROJECT_BINARY_DIR})
 # Compiler flags
 
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0 -fPIC")
 endif()
 
 # Recurse into main project directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ set(USE_RCCL_DEFAULT OFF)
 set(USE_LIBUV_DEFAULT OFF)
 set(USE_TCP_OPENSSL_LINK_DEFAULT OFF)
 set(USE_TCP_OPENSSL_LOAD_DEFAULT OFF)
-set(CMAKE_CXX_STANDARD 14)
 
 # Options
 option(USE_REDIS "Support using Redis for rendezvous" ${USE_REDIS_DEFAULT})
@@ -118,7 +117,7 @@ include_directories(${PROJECT_BINARY_DIR})
 # Compiler flags
 
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0 -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
 endif()
 
 # Recurse into main project directory

--- a/gloo/CMakeLists.txt
+++ b/gloo/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND GLOO_HDRS
   "${CMAKE_CURRENT_SOURCE_DIR}/broadcast_one_to_all.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/context.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/gather.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/gatherv.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/math.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/pairwise_exchange.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/reduce.h"

--- a/gloo/gatherv.cc
+++ b/gloo/gatherv.cc
@@ -104,9 +104,7 @@ void gatherv(GathervOptions& opts) {
       out->waitRecv(opts.timeout);
     }
   } else {
-    size_t sendLength = opts.elementSize * opts.elementsPerRank[context->rank];
-    GLOO_ENFORCE_GE(in->size, sendLength);
-    in->send(opts.root, slot, 0, sendLength);
+    in->send(opts.root, slot, 0, in->size);
     in->waitSend(opts.timeout);
   }
 }


### PR DESCRIPTION
1. gatherv.h is not installed by the command of `make install`
2. in gloo/gatherv.cc, `GLOO_ENFORCE_GE` is a wrong check, for example: there are two tasks, A task send 3 and 4 elements to task A and task B, respectively, while task B send 5 and 6 elements to task A and task B, respectively. In this way, the `opts.elementsPerRank` of task A will be 3 and 5, apparently, 4 (the number of elements send to task B) is not greater equal than 5 (the number of elements receive from task B). 

1. gatherv.h在执行make install 时并没有拷贝到对应的目录，导致不能使用
2. 在gloo/gatherv.cc的107行和108行中，GLOO_ENFORCE_GE在这里的校验是错误的。比如，如果有两个任务，任务A分别向任务A和任务B发送3和4个数据，任务B分别向任务A和任务B发送5个和6个数据。那么对于任务A，则其opts.elementsPerRank将会是3和5，显然4（发送给任务B的数据量）并不是大于等于5（从任务B中收到的数据量）的。