### PR TITLE
Delete default error constructors

### DIFF
--- a/gloo/common/error.h
+++ b/gloo/common/error.h
@@ -22,7 +22,7 @@ const std::chrono::milliseconds kNoTimeout = std::chrono::milliseconds::zero();
 
 // A base class for all gloo runtime errors
 struct Exception : public std::runtime_error {
-  Exception() = default;
+  Exception() = delete;
   explicit Exception(const std::string& msg) : std::runtime_error(msg) {}
 };
 
@@ -32,7 +32,7 @@ struct Exception : public std::runtime_error {
 
 // Thrown for invalid operations on gloo APIs
 struct InvalidOperationException : public ::gloo::Exception {
-  InvalidOperationException() = default;
+  InvalidOperationException() = delete;
   explicit InvalidOperationException(const std::string& msg)
       : ::gloo::Exception(msg) {}
 };
@@ -43,7 +43,7 @@ struct InvalidOperationException : public ::gloo::Exception {
 
 // Thrown for unrecoverable IO errors
 struct IoException : public ::gloo::Exception {
-  IoException() = default;
+  IoException() = delete;
   explicit IoException(const std::string& msg) : ::gloo::Exception(msg) {}
 };
 


### PR DESCRIPTION
As they should have been deleted, since `std::runtime_error` does not provide a default constructor.

Fixes following compilation warnings:
```
/Users/malfet/git/pytorch/pytorch/third_party/gloo/gloo/common/error.h:25:3: warning: explicitly defaulted default constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Exception() = default;
  ^
/Users/malfet/git/pytorch/pytorch/third_party/gloo/gloo/common/error.h:24:20: note: default constructor of 'Exception' is implicitly deleted because base class 'std::runtime_error' has no default constructor
struct Exception : public std::runtime_error {
                   ^
/Users/malfet/git/pytorch/pytorch/third_party/gloo/gloo/common/error.h:35:3: warning: explicitly defaulted default constructor is implicitly deleted [-Wdefaulted-function-deleted]
  InvalidOperationException() = default;
  ^
/Users/malfet/git/pytorch/pytorch/third_party/gloo/gloo/common/error.h:34:36: note: default constructor of 'InvalidOperationException' is implicitly deleted because base class '::gloo::Exception' has a deleted default constructor
struct InvalidOperationException : public ::gloo::Exception {
                                   ^
/Users/malfet/git/pytorch/pytorch/third_party/gloo/gloo/common/error.h:25:3: note: explicitly defaulted function was implicitly deleted here
  Exception() = default;
  ^
/Users/malfet/git/pytorch/pytorch/third_party/gloo/gloo/common/error.h:24:20: note: default constructor of 'Exception' is implicitly deleted because base class 'std::runtime_error' has no default constructor
struct Exception : public std::runtime_error {
                   ^
/Users/malfet/git/pytorch/pytorch/third_party/gloo/gloo/common/error.h:46:3: warning: explicitly defaulted default constructor is implicitly deleted [-Wdefaulted-function-deleted]
  IoException() = default;
  ^
/Users/malfet/git/pytorch/pytorch/third_party/gloo/gloo/common/error.h:45:22: note: default constructor of 'IoException' is implicitly deleted because base class '::gloo::Exception' has a deleted default constructor
struct IoException : public ::gloo::Exception {
                     ^
/Users/malfet/git/pytorch/pytorch/third_party/gloo/gloo/common/error.h:25:3: note: explicitly defaulted function was implicitly deleted here
  Exception() = default;
  ^
/Users/malfet/git/pytorch/pytorch/third_party/gloo/gloo/common/error.h:24:20: note: default constructor of 'Exception' is implicitly deleted because base class 'std::runtime_error' has no default constructor
struct Exception : public std::runtime_error {
                   ^
3 warnings generated.
```