### PR TITLE
[ROCm] Updates to remove HIP deprecated symbols

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -155,13 +155,13 @@ if(USE_ROCM)
     list(APPEND HIP_CXX_FLAGS -Wno-duplicate-decl-specifier)
     list(APPEND HIP_CXX_FLAGS -DUSE_MIOPEN)
 
-    set(HIP_HCC_FLAGS ${HIP_CXX_FLAGS})
+    set(HIP_CLANG_FLAGS ${HIP_CXX_FLAGS})
     # Ask hcc to generate device code during compilation so we can use
     # host linker to link.
-    list(APPEND HIP_HCC_FLAGS -fno-gpu-rdc)
-    list(APPEND HIP_HCC_FLAGS -Wno-defaulted-function-deleted)
+    list(APPEND HIP_CLANG_FLAGS -fno-gpu-rdc)
+    list(APPEND HIP_CLANG_FLAGS -Wno-defaulted-function-deleted)
     foreach(gloo_rocm_arch ${GLOO_ROCM_ARCH})
-      list(APPEND HIP_HCC_FLAGS --amdgpu-target=${gloo_rocm_arch})
+      list(APPEND HIP_CLANG_FLAGS --amdgpu-target=${gloo_rocm_arch})
     endforeach()
 
     set(GLOO_HIP_INCLUDE ${hip_INCLUDE_DIRS} $<BUILD_INTERFACE:${HIPIFY_OUTPUT_ROOT_DIR}> $<INSTALL_INTERFACE:include> ${GLOO_HIP_INCLUDE})

--- a/cmake/Modules/Findrccl.cmake
+++ b/cmake/Modules/Findrccl.cmake
@@ -21,7 +21,7 @@ else()
 endif()
 
 find_path(RCCL_INCLUDE_DIR
-  NAMES rccl.h
+  NAMES rccl/rccl.h
   HINTS
   ${RCCL_INCLUDE_DIR}
   ${RCCL_ROOT_DIR}/include)
@@ -33,17 +33,17 @@ else()
   set(RCCL_LIBNAME "rccl")
 endif()
 
-find_library(RCCL_LIBRARY
+find_library(RCCL_LIB_PATH
   NAMES ${RCCL_LIBNAME}
   HINTS
   ${RCCL_LIB_DIR}
   ${RCCL_ROOT_DIR}/lib)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(RCCL DEFAULT_MSG RCCL_INCLUDE_DIR RCCL_LIBRARY)
+find_package_handle_standard_args(RCCL DEFAULT_MSG RCCL_INCLUDE_DIR RCCL_LIB_PATH)
 
 if (RCCL_FOUND)
-  set(RCCL_HEADER_FILE "${RCCL_INCLUDE_DIR}/rccl.h")
+  set(RCCL_HEADER_FILE "${RCCL_INCLUDE_DIR}/rccl/rccl.h")
   message(STATUS "Determining RCCL version from the header file: ${RCCL_HEADER_FILE}")
   file (STRINGS ${RCCL_HEADER_FILE} RCCL_MAJOR_VERSION_DEFINED
         REGEX "^[ \t]*#define[ \t]+RCCL_MAJOR[ \t]+[0-9]+.*$" LIMIT_COUNT 1)
@@ -53,7 +53,7 @@ if (RCCL_FOUND)
     message(STATUS "RCCL_MAJOR_VERSION: ${RCCL_MAJOR_VERSION}")
   endif()
   set(RCCL_INCLUDE_DIRS ${RCCL_INCLUDE_DIR})
-  set(RCCL_LIBRARIES ${RCCL_LIBRARY})
+  set(RCCL_LIBRARIES ${RCCL_LIB_PATH})
   message(STATUS "Found RCCL (include: ${RCCL_INCLUDE_DIRS}, library: ${RCCL_LIBRARIES})")
   mark_as_advanced(RCCL_ROOT_DIR RCCL_INCLUDE_DIRS RCCL_LIBRARIES)
 endif()

--- a/tools/amd_build/pyHIPIFY/cuda_to_hip_mappings.py
+++ b/tools/amd_build/pyHIPIFY/cuda_to_hip_mappings.py
@@ -7784,7 +7784,7 @@ GLOO_SPECIFIC_MAPPINGS = collections.OrderedDict(
         ("cudnn", ("miopen", API_GLOO)),
         ("namespace cuda", ("namespace hip", API_GLOO)),
         ("gloo/cuda.h", ("gloo/hip.h", API_GLOO)),
-        ("<nccl.h>", ("<rccl.h>", API_GLOO)),
+        ("<nccl.h>", ("<rccl/rccl.h>", API_GLOO)),
         ("GLOO_USE_NCCL", ("GLOO_USE_RCCL", API_GLOO)),
     ]
 )


### PR DESCRIPTION
- Removed usage of HIP_HCC_FLAGS
- Proper of include path for rccl.h