### PR TITLE
Increase socket buffer size to allow ProcessGroup init up to 12k ranks

### DIFF
--- a/gloo/transport/tcp/listener.h
+++ b/gloo/transport/tcp/listener.h
@@ -32,7 +32,7 @@ class Listener final : public Handler {
   using connect_callback_t =
       std::function<void(std::shared_ptr<Socket> socket, Error error)>;
 
-  static constexpr int kBacklog = 2048;
+  static constexpr int kBacklog = -1;  // allow somaxconn
 
   Listener(std::shared_ptr<Loop> loop, const attr& attr);
 


### PR DESCRIPTION
Summary: The c10d socket and gloo listener both set their buffer size to 2048 which causes connection issue at 4k scale. This diff sets the buffer size to `-1` which uses `somaxconn` as the actual buffer size, aiming to enable 24k PG init without crash. The experiment shows the ability to successful creation of 12k ranks without crash.

Reviewed By: wconstab, bmaurer

Differential Revision: D48617912

