### PR TITLE
Remove extra semi colon from glean/tools/deadcode/tests/includes/test_intermediate_namespace.cpp

### DIFF
--- a/gloo/barrier.h
+++ b/gloo/barrier.h
@@ -19,7 +19,7 @@ class Barrier : public Algorithm {
   explicit Barrier(const std::shared_ptr<Context>& context)
       : Algorithm(context) {}
 
-  virtual ~Barrier(){};
+  virtual ~Barrier(){}
 };
 
 class BarrierOptions {

--- a/gloo/test/math_test.cc
+++ b/gloo/test/math_test.cc
@@ -72,7 +72,7 @@ TYPED_TEST(MathTest, Sum) {
       }
     }
   }
-};
+}
 
 TYPED_TEST(MathTest, Product) {
   std::array<TypeParam, num> a, b, c;
@@ -94,7 +94,7 @@ TYPED_TEST(MathTest, Product) {
       }
     }
   }
-};
+}
 
 TYPED_TEST(MathTest, Min) {
   std::array<TypeParam, num> a, b, c;
@@ -116,7 +116,7 @@ TYPED_TEST(MathTest, Min) {
       }
     }
   }
-};
+}
 
 TYPED_TEST(MathTest, Max) {
   std::array<TypeParam, num> a, b, c;
@@ -138,7 +138,7 @@ TYPED_TEST(MathTest, Max) {
       }
     }
   }
-};
+}
 
 template <typename TypeParam>
 void perf(void (*fn)(void* c, const void* a, const void* b, size_t n)) {

--- a/gloo/transport/ibverbs/pair.cc
+++ b/gloo/transport/ibverbs/pair.cc
@@ -535,7 +535,7 @@ void Pair::signalIoFailure(const std::string& msg) {
   }
   // Finally, throw the exception on this thread.
   throw ex;
-};
+}
 
 void Pair::checkErrorState() {
   // If we previously encountered an error, rethrow here.


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51995044


