### PR TITLE
Remove unused exception parameter from gloo/rendezvous/context.cc

### DIFF
--- a/gloo/rendezvous/context.cc
+++ b/gloo/rendezvous/context.cc
@@ -46,7 +46,7 @@ ContextFactory::ContextFactory(std::shared_ptr<::gloo::Context> backingContext)
       GLOO_ENFORCE(
         backingContext_->getPair(i) != nullptr,
         "Missing pair in backing context");
-    } catch(std::out_of_range& e) {
+    } catch(std::out_of_range& ) {
       GLOO_THROW("Backing context not fully connected");
     }
   }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51785901


