### PR TITLE
Changing the count parameter type from int to size_t in reduction algorithms.

### DIFF
--- a/gloo/allreduce_bcube.h
+++ b/gloo/allreduce_bcube.h
@@ -258,7 +258,7 @@ class AllreduceBcube : public Algorithm {
   AllreduceBcube(
       const std::shared_ptr<Context>& context,
       const std::vector<T*> ptrs,
-      const int count,
+      const size_t count,
       const ReductionFunction<T>* fn = ReductionFunction<T>::sum)
       : Algorithm(context),
         myRank_(this->context_->rank),
@@ -461,11 +461,11 @@ class AllreduceBcube : public Algorithm {
   /**
    * Total number of elements to process
    */
-  const int totalNumElems_{0};
+  const size_t totalNumElems_{0};
   /**
    * Total number of bytes to process
    */
-  const int bytes_{0};
+  const size_t bytes_{0};
   /**
    * Total number of steps
    */

--- a/gloo/allreduce_halving_doubling.h
+++ b/gloo/allreduce_halving_doubling.h
@@ -67,7 +67,7 @@ class AllreduceHalvingDoubling : public Algorithm {
   AllreduceHalvingDoubling(
       const std::shared_ptr<Context>& context,
       const std::vector<T*> ptrs,
-      const int count,
+      const size_t count,
       const ReductionFunction<T>* fn = ReductionFunction<T>::sum)
       : Algorithm(context),
         ptrs_(ptrs),
@@ -362,8 +362,8 @@ class AllreduceHalvingDoubling : public Algorithm {
 
  protected:
   std::vector<T*> ptrs_;
-  const int count_;
-  const int bytes_;
+  const size_t count_;
+  const size_t bytes_;
   const size_t steps_;
   const size_t chunks_;
   const size_t chunkSize_;

--- a/gloo/allreduce_local.cc
+++ b/gloo/allreduce_local.cc
@@ -16,7 +16,7 @@ template <typename T>
 AllreduceLocal<T>::AllreduceLocal(
     const std::shared_ptr<Context>& context,
     const std::vector<T*>& ptrs,
-    const int count,
+    const size_t count,
     const ReductionFunction<T>* fn)
     : Algorithm(context),
       ptrs_(ptrs),

--- a/gloo/allreduce_local.h
+++ b/gloo/allreduce_local.h
@@ -19,7 +19,7 @@ class AllreduceLocal : public Algorithm {
   AllreduceLocal(
       const std::shared_ptr<Context>& context,
       const std::vector<T*>& ptrs,
-      const int count,
+      const size_t count,
       const ReductionFunction<T>* fn = ReductionFunction<T>::sum);
 
   virtual ~AllreduceLocal() = default;
@@ -28,8 +28,8 @@ class AllreduceLocal : public Algorithm {
 
  protected:
   std::vector<T*> ptrs_;
-  const int count_;
-  const int bytes_;
+  const size_t count_;
+  const size_t bytes_;
   const ReductionFunction<T>* fn_;
 };
 

--- a/gloo/allreduce_ring.h
+++ b/gloo/allreduce_ring.h
@@ -22,7 +22,7 @@ class AllreduceRing : public Algorithm {
   AllreduceRing(
       const std::shared_ptr<Context>& context,
       const std::vector<T*>& ptrs,
-      const int count,
+      const size_t count,
       const ReductionFunction<T>* fn = ReductionFunction<T>::sum)
       : Algorithm(context),
         ptrs_(ptrs),
@@ -114,8 +114,8 @@ class AllreduceRing : public Algorithm {
 
  protected:
   std::vector<T*> ptrs_;
-  const int count_;
-  const int bytes_;
+  const size_t count_;
+  const size_t bytes_;
   const ReductionFunction<T>* fn_;
 
   T* inbox_;

--- a/gloo/allreduce_ring_chunked.h
+++ b/gloo/allreduce_ring_chunked.h
@@ -22,7 +22,7 @@ class AllreduceRingChunked : public Algorithm {
   AllreduceRingChunked(
       const std::shared_ptr<Context>& context,
       const std::vector<T*>& ptrs,
-      const int count,
+      const size_t count,
       const ReductionFunction<T>* fn = ReductionFunction<T>::sum)
       : Algorithm(context),
         ptrs_(ptrs),
@@ -236,8 +236,8 @@ class AllreduceRingChunked : public Algorithm {
   }
 
   std::vector<T*> ptrs_;
-  const int count_;
-  const int bytes_;
+  const size_t count_;
+  const size_t bytes_;
   const ReductionFunction<T>* fn_;
 
   size_t chunks_;


### PR DESCRIPTION
1. Int means that user cannot pass an array size larger than numeric_limits<int>::max
2. Signed type deosn't make sense regarding the size of the array, which cannot be less than 0.
3. In many places under the hood, count is converted to size_t anyway, e.g. malloc
4. gloo/gloo/allreduce.h uses size_t as number of elements which is inconsistent with other reduction algorithms
5. ReductionFunction<T> takes size_t as count parameter
6. While experimenting with examples, I ran into a problem with the number of elements being limited by int. It took me a while to figure out why the code wasn't working. Other users may also encounter this problem.