### PR TITLE
Add missing isConnected override to uv transport

### DIFF
--- a/gloo/transport/uv/pair.cc
+++ b/gloo/transport/uv/pair.cc
@@ -52,6 +52,11 @@ const Address& Pair::address() const {
   return addr_;
 }
 
+bool Pair::isConnected() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return state_ == CONNECTED;
+}
+
 void Pair::connect(const std::vector<char>& bytes) {
   const auto peer = Address(bytes);
 

--- a/gloo/transport/uv/pair.h
+++ b/gloo/transport/uv/pair.h
@@ -150,6 +150,8 @@ class Pair : public ::gloo::transport::Pair {
 
   void close() override;
 
+  bool isConnected() override;
+
  private:
   std::mutex mutex_;
   std::condition_variable cv_;


### PR DESCRIPTION
Project does not build with -DUSE_LIBUV=ON , due to the introduction of virtual isConnected() in base Pair class. This patch fixes it.