### PR TITLE
Fix wrong struct layout in getInterfaceSpeedGLinkSettings

### DIFF
--- a/gloo/common/linux.cc
+++ b/gloo/common/linux.cc
@@ -192,9 +192,12 @@ const std::string& infinibandToBusID(const std::string& name) {
 static int getInterfaceSpeedGLinkSettings(int sock, struct ifreq* ifr) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
   constexpr auto link_mode_data_nwords = 3 * 127;
-  struct {
-    __u32 link_mode_data[link_mode_data_nwords];
+  union {
     struct ethtool_link_settings req;
+    struct { // Only to provide the memory
+      __u32 link_mode_data[link_mode_data_nwords];
+      struct ethtool_link_settings dummy;
+    };
   } ecmd;
   int rv;
 


### PR DESCRIPTION
The `SIOCETHTOOL` IOCTL expects a pointer to an instance of `ethtool_link_settings`.
E.g. it will read the `cmd` member to determine what to do. However #346 reordered the memory layout of the pointer such that actually and array of `__32` values (zeroed out) is passed. Hence the IOCTL will either fail because an invalid command (`cmd=0`) is passed or the values read later by e.g.
`ecmd.req.link_mode_masks_nwords` are something completely different.

So `ethtool_link_settings` has to come before the (stack) memory used in the flexible array at the end of this struct.
To avoid GCC warnigns/errors (see #345) an union is used that provides the current struct (i.e. with wrong order) and an access the actually used `struct ethtool_link_settings` at the top.

Alternative approach to https://github.com/facebookincubator/gloo/pull/348 likely avoiding any undefined behavior (union based type punning is usually supported by compilers, so this should work to get the required memory)