### PR TITLE
[vcpkg] Fix the order of structures to adapt to the linu kernel

### DIFF
--- a/gloo/common/linux.cc
+++ b/gloo/common/linux.cc
@@ -21,6 +21,9 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
Hi, all. I am the maintainer of vcpkg.

Recently we received a build error regarding gloo. https://github.com/microsoft/vcpkg/issues/38852

**Reproduce**:
```
git clone https://github.com/microsoft/vcpkg
cd vcpkg/
./vcpkg install gloo:x64-linux
```
**Error**:
```
FAILED: gloo/CMakeFiles/gloo.dir/common/linux.cc.o 
/usr/bin/c++  -I/mnt/c/Kiko/Tools/vcpkg/buildtrees/gloo/src/4842d821e2-a23aea63a5.clean -I/mnt/c/Kiko/Tools/vcpkg/buildtrees/gloo/x64-linux-dbg -fPIC -std=c++11 -fPIC -g -MD -MT gloo/CMakeFiles/gloo.dir/common/linux.cc.o -MF gloo/CMakeFiles/gloo.dir/common/linux.cc.o.d -o gloo/CMakeFiles/gloo.dir/common/linux.cc.o -c /mnt/c/Kiko/Tools/vcpkg/buildtrees/gloo/src/4842d821e2-a23aea63a5.clean/gloo/common/linux.cc
In file included from /mnt/c/Kiko/Tools/vcpkg/buildtrees/gloo/src/4842d821e2-a23aea63a5.clean/gloo/common/linux.cc:15:
/usr/include/linux/ethtool.h: In function ‘int gloo::getInterfaceSpeedGLinkSettings(int, ifreq*)’:
/usr/include/linux/ethtool.h:2214:17: error: flexible array member ‘ethtool_link_settings::link_mode_masks’ not at end of ‘struct gloo::getInterfaceSpeedGLinkSettings(int, ifreq*)::<unnamed>’
 2214 |         __u32   link_mode_masks[];
      |                 ^~~~~~~~~~~~~~~
/mnt/c/Kiko/Tools/vcpkg/buildtrees/gloo/src/4842d821e2-a23aea63a5.clean/gloo/common/linux.cc:192:11: note: next member ‘__u32 gloo::getInterfaceSpeedGLinkSettings(int, ifreq*)::<unnamed struct>::link_mode_data [381]’ declared here
  192 |     __u32 link_mode_data[link_mode_data_nwords];
      |           ^~~~~~~~~~~~~~
/mnt/c/Kiko/Tools/vcpkg/buildtrees/gloo/src/4842d821e2-a23aea63a5.clean/gloo/common/linux.cc:190:10: note: in the definition of ‘struct gloo::getInterfaceSpeedGLinkSettings(int, ifreq*)::<unnamed>’
  190 |   struct {
      |          ^
```

**Solution**:
I think the flexible array member link_mode_masks should be at the end of the structure, otherwise it is illegal in C++.

And this structure requires dynamic allocation of memory to ensure that the flexible array members have enough space to store the required data.

I reorganized the structure and used `malloc ` for dynamic allocation of memory.
I will get your help as soon as possible. :)