### PR TITLE
gcc-15 porting

### DIFF
--- a/gloo/types.h
+++ b/gloo/types.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <iostream>
+#include <cstdint>
 
 #ifdef __CUDA_ARCH__
 #include <cuda.h>


### PR DESCRIPTION
cstdint for uint8_t need to be included explicitly when compiling with GCC 15