### PR TITLE
fix(benchmark): add definition of static constexpr member variable

### DIFF
--- a/gloo/rendezvous/store.cc
+++ b/gloo/rendezvous/store.cc
@@ -6,6 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "store.h"
+
 namespace gloo {
-namespace rendezvous {} // namespace rendezvous
+namespace rendezvous {
+constexpr std::chrono::milliseconds Store::kDefaultTimeout;
+} // namespace rendezvous
 } // namespace gloo


### PR DESCRIPTION
prior to C++17, definition is necessary
fix #389