### PR TITLE
allow seq_number == global_rank for TCP backend

### DIFF
--- a/gloo/common/utils.cc
+++ b/gloo/common/utils.cc
@@ -30,4 +30,10 @@ std::string getHostname() {
   return std::string(hostname);
 }
 
+bool useRankAsSeqNumber() {
+  const auto& res = getenv("GLOO_ENABLE_RANK_AS_SEQUENCE_NUMBER");
+  return res != nullptr &&
+      (std::string(res) == "True" || std::string(res) == "1");
+}
+
 } // namespace gloo

--- a/gloo/common/utils.h
+++ b/gloo/common/utils.h
@@ -14,4 +14,6 @@ namespace gloo {
 
 std::string getHostname();
 
+bool useRankAsSeqNumber();
+
 } // namespace gloo

--- a/gloo/transport/tcp/context.h
+++ b/gloo/transport/tcp/context.h
@@ -39,6 +39,9 @@ class Context : public ::gloo::transport::Context,
   virtual void createAndConnectAllPairs(IStore& store) override;
 
   std::unique_ptr<transport::Pair>& createPair(int rank) override;
+  std::unique_ptr<transport::Pair>& createPair(
+      int rank,
+      bool useRankAsSeqNumber);
 
   std::unique_ptr<transport::UnboundBuffer> createUnboundBuffer(
       void* ptr,

--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -253,6 +253,10 @@ Address Device::nextAddress() {
   return listener_->nextAddress();
 }
 
+Address Device::nextAddress(int seq) {
+  return listener_->nextAddress(seq);
+}
+
 bool Device::isInitiator(const Address& local, const Address& remote) const {
   int rv = 0;
   // The remote side of a pair will be called with the same

--- a/gloo/transport/tcp/device.h
+++ b/gloo/transport/tcp/device.h
@@ -68,6 +68,15 @@ class Device : public ::gloo::transport::Device,
   //
   Address nextAddress();
 
+  // Return a new `Address` instance using the provided sequence number.
+  //
+  // This is called by the constructor of the `Pair` class. It gives
+  // the pair a uniquely identifying address even though the device
+  // uses a shared listening socket. Caller must provide a unique sequence
+  // number
+  //
+  Address nextAddress(int);
+
   // Connect a pair to a remote.
   //
   // This is performed by the device instance because we use a single

--- a/gloo/transport/tcp/listener.cc
+++ b/gloo/transport/tcp/listener.cc
@@ -13,6 +13,7 @@
 
 #include <gloo/common/common.h>
 #include <gloo/common/logging.h>
+#include <gloo/common/utils.h>
 #include <gloo/transport/tcp/helpers.h>
 
 namespace gloo {
@@ -26,6 +27,7 @@ Listener::Listener(std::shared_ptr<Loop> loop, const attr& attr)
   listener_->bind(attr.ai_addr);
   listener_->listen(kBacklog);
   addr_ = listener_->sockName();
+  useRankAsSeqNumber_ = useRankAsSeqNumber();
 
   // Register with loop for readability events.
   loop_->registerDescriptor(listener_->fd(), EPOLLIN, this);
@@ -76,7 +78,17 @@ void Listener::handleEvents(int /* unused */) {
 
 Address Listener::nextAddress() {
   std::lock_guard<std::mutex> guard(mutex_);
+  GLOO_ENFORCE(
+      !useRankAsSeqNumber_,
+      "Listener cannot use internal sequence with enabled option to use rank as sequence number");
   return Address(addr_.getSockaddr(), seq_++);
+}
+
+Address Listener::nextAddress(int seq) {
+  GLOO_ENFORCE(
+      useRankAsSeqNumber_,
+      "Listener must be setup to use rank as sequence number");
+  return Address(addr_.getSockaddr(), seq);
 }
 
 void Listener::waitForConnection(sequence_number_t seq, connect_callback_t fn) {

--- a/gloo/transport/tcp/listener.h
+++ b/gloo/transport/tcp/listener.h
@@ -42,6 +42,8 @@ class Listener final : public Handler {
 
   Address nextAddress();
 
+  Address nextAddress(int);
+
   // Wait for connection with sequence number `seq`. The callback is
   // always called from a different thread (the event loop thread),
   // even if the connection is already available.
@@ -67,6 +69,12 @@ class Listener final : public Handler {
 
   // Sockets by sequence number (while waiting for a pair to call).
   std::unordered_map<sequence_number_t, std::shared_ptr<Socket>> seqToSocket_;
+
+  // Option to use rank as sequence number and avoid pair identifiers
+  // to the store during rendezvous. Experimental, disabled by default.
+  // Can be enabled by setting the environment variable
+  // GLOO_ENABLE_RANK_AS_SEQUENCE_NUMBER=1.
+  bool useRankAsSeqNumber_{false};
 };
 
 } // namespace tcp

--- a/gloo/transport/tcp/pair.cc
+++ b/gloo/transport/tcp/pair.cc
@@ -46,7 +46,8 @@ Pair::Pair(
     Context* context,
     Device* device,
     int rank,
-    std::chrono::milliseconds timeout)
+    std::chrono::milliseconds timeout,
+    bool useRankAsSeqNumber)
     : context_(context),
       device_(device),
       rank_(rank),
@@ -56,7 +57,9 @@ Pair::Pair(
       busyPoll_(false),
       fd_(FD_INVALID),
       sendBufferSize_(0),
-      self_(device_->nextAddress()),
+      self_(
+          useRankAsSeqNumber ? device_->nextAddress(rank)
+                             : device_->nextAddress()),
       ex_(nullptr) {}
 
 // Destructor performs a "soft" close.

--- a/gloo/transport/tcp/pair.h
+++ b/gloo/transport/tcp/pair.h
@@ -95,7 +95,8 @@ class Pair : public ::gloo::transport::Pair, public Handler {
       Context* context,
       Device* device,
       int rank,
-      std::chrono::milliseconds timeout);
+      std::chrono::milliseconds timeout,
+      bool useRankAsSeqNumber = false);
 
   virtual ~Pair();
 


### PR DESCRIPTION
Summary:
All credit goes to original author XilunWu. I am just landing the code to unblock large training jobs.

D45740631 reduces gloo rendezvous cost for TCP backend by eliminating duplicate address publishing to TCPStore. Ben suggested "have seq_number == global_rank" to further get rid of `seq_number` exchange and Shawn reported why this didn't work. This diff serves a starting point for benchmarking the benefit of doing so ([testbed record](https://docs.google.com/document/d/1_p390fx0IiaZWbt-Dkdvp9jSgCKebiuG8_a6BVjHtMU/edit) shows 2x speedup: 46 min ProcessGroupGloo init time on 8k ranks -> 20 min).

The feature will be enabled via env variable (GLOO_ENABLE_RANK_AS_SEQUENCE_NUMBER) disabled by default that will be controlled by justKnobs.

Reviewed By: XilunWu

Differential Revision: D48130088


