### PR TITLE
Use multi_get for store that has extended API support.

### DIFF
--- a/gloo/common/store.h
+++ b/gloo/common/store.h
@@ -25,6 +25,21 @@ class IStore {
   virtual void wait(
       const std::vector<std::string>& keys,
       const std::chrono::milliseconds& timeout) = 0;
+
+  // Extended 2.0 API support
+  virtual bool has_v2_support() = 0;
+
+  virtual std::vector<std::vector<char>> multi_get(
+      const std::vector<std::string>& keys) = 0;
+
+  virtual void multi_set(
+      const std::vector<std::string>& keys,
+      const std::vector<std::vector<char>>& values) = 0;
+
+  virtual void append(
+      const std::string& key,
+      const std::vector<char>& value) = 0;
+  virtual int64_t add(const std::string& key, int64_t value) = 0;
 };
 
 } // namespace gloo

--- a/gloo/common/utils.cc
+++ b/gloo/common/utils.cc
@@ -36,4 +36,10 @@ bool useRankAsSeqNumber() {
       (std::string(res) == "True" || std::string(res) == "1");
 }
 
+bool isStoreExtendedApiEnabled() {
+  const auto& res = std::getenv("GLOO_ENABLE_STORE_V2_API");
+  return res != nullptr &&
+      (std::string(res) == "True" || std::string(res) == "1");
+}
+
 } // namespace gloo

--- a/gloo/common/utils.h
+++ b/gloo/common/utils.h
@@ -16,4 +16,6 @@ std::string getHostname();
 
 bool useRankAsSeqNumber();
 
+bool isStoreExtendedApiEnabled();
+
 } // namespace gloo

--- a/gloo/transport/tcp/listener.cc
+++ b/gloo/transport/tcp/listener.cc
@@ -15,6 +15,7 @@
 #include <gloo/common/logging.h>
 #include <gloo/common/utils.h>
 #include <gloo/transport/tcp/helpers.h>
+#
 
 namespace gloo {
 namespace transport {


### PR DESCRIPTION
Summary:
The TCP store has API v2 support we can reduce the network overhead of Gloo rendezvous significantly by fetching a batch of key instead of doing them one by one.
Initial testing shows ~15X improvement for 4k jobs.

Gloo process group init:

Baseline ( fbcode trunk):
2k job (https://fburl.com/mlhub/x1prxu89) : ~82sec (~1.4 min)
4k job (https://fburl.com/mlhub/v1djk4n5) : ~393 sec (~6.6min)
8k job (https://fburl.com/mlhub/cagqrs7m): (~55mins)

With optimizations (D48130088 + D52083376):

2k job (https://fburl.com/mlhub/x0cskdag)  : ~18 sec ( ~5x faster)
4k job (https://fburl.com/mlhub/xzmvkm4j) : ~ 25 sec (~15x faster)
8k job (https://fburl.com/mlhub/gdyeizv9)   : ~ 85 sec (~35x faster)

Reviewed By: xunnanxu

Differential Revision:
D52083376

Privacy Context Container: L1156430


