### PR TITLE
gloo: fix error what

### DIFF
--- a/gloo/transport/tcp/device.h
+++ b/gloo/transport/tcp/device.h
@@ -91,7 +91,7 @@ class Device : public ::gloo::transport::Device,
   // connection is cached in a map, using the sequence number.
   //
   using connect_callback_t =
-      std::function<void(std::shared_ptr<Socket> socket, Error error)>;
+      std::function<void(std::shared_ptr<Socket> socket, const Error& error)>;
 
   void connect(
       const Address& local,

--- a/gloo/transport/tcp/error.h
+++ b/gloo/transport/tcp/error.h
@@ -23,6 +23,10 @@ class Error {
 
   virtual ~Error() = default;
 
+  // Don't allow Error to be copied or moved to avoid losing the error message.
+  Error(const Error&) = delete;
+  Error& operator=(const Error&) = delete;
+
   // Converting to boolean means checking if there is an error. This
   // means we don't need to use an `std::optional` and allows for a
   // snippet like the following:

--- a/gloo/transport/tcp/listener.h
+++ b/gloo/transport/tcp/listener.h
@@ -30,7 +30,7 @@ namespace tcp {
 class Listener final : public Handler {
  public:
   using connect_callback_t =
-      std::function<void(std::shared_ptr<Socket> socket, Error error)>;
+      std::function<void(std::shared_ptr<Socket> socket, const Error& error)>;
 
   static constexpr int kBacklog = -1; // allow somaxconn
 

--- a/gloo/transport/tcp/pair.cc
+++ b/gloo/transport/tcp/pair.cc
@@ -141,7 +141,7 @@ void Pair::connect(const std::vector<char>& bytes) {
   waitUntilConnected(lock, true);
 }
 
-void Pair::connectCallback(std::shared_ptr<Socket> socket, Error error) {
+void Pair::connectCallback(std::shared_ptr<Socket> socket, const Error& error) {
   std::lock_guard<std::mutex> lock(m_);
   if (error) {
     signalException(GLOO_ERROR_MSG(error.what()));

--- a/gloo/transport/tcp/pair.h
+++ b/gloo/transport/tcp/pair.h
@@ -190,7 +190,7 @@ class Pair : public ::gloo::transport::Pair, public Handler {
   void sendNotifyRecvReady(uint64_t slot, size_t nbytes);
   void sendNotifySendReady(uint64_t slot, size_t nbytes);
 
-  void connectCallback(std::shared_ptr<Socket> socket, Error error);
+  void connectCallback(std::shared_ptr<Socket> socket, const Error& error);
 
   Buffer* getBuffer(int slot);
   void registerBuffer(Buffer* buf);


### PR DESCRIPTION
Summary:
This fixes the Gloo TCP transport error handling so errors don't accidentally get casted to `Error` which results in a `no error` message on connection errors.

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  [fbcode/gloo/transport/tcp/pair.cc:147] no error
```

Differential Revision: D70212634


