### PR TITLE
Fix missing header for getenv

### DIFF
--- a/gloo/common/utils.cc
+++ b/gloo/common/utils.cc
@@ -11,7 +11,7 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #else
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
 #endif
 

--- a/gloo/common/utils.cc
+++ b/gloo/common/utils.cc
@@ -11,8 +11,8 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #else
-#include <cstdlib>
 #include <unistd.h>
+#include <cstdlib>
 #endif
 
 #include "gloo/common/utils.h"

--- a/gloo/common/utils.cc
+++ b/gloo/common/utils.cc
@@ -11,6 +11,7 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #else
+#include <stdlib.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
getenv can't be found on MacOS Apple Silicon.