### PR TITLE
Use `nullptr` in gloo/cuda_allreduce_halving_doubling.h

### DIFF
--- a/gloo/cuda_allreduce_halving_doubling.h
+++ b/gloo/cuda_allreduce_halving_doubling.h
@@ -60,7 +60,7 @@ class CudaAllreduceHalvingDoubling : public Algorithm {
   void initReductionsAndBroadcasts(
       typename std::enable_if<
           std::is_same<U, CudaDeviceWorkspace<T>>::value,
-          typename U::Pointer>::type* = 0);
+          typename U::Pointer>::type* = NULL);
 
   std::vector<CudaDevicePointer<T>> devicePtrs_;
   std::vector<CudaStream> streams_;

--- a/gloo/cuda_broadcast_one_to_all.h
+++ b/gloo/cuda_broadcast_one_to_all.h
@@ -36,13 +36,13 @@ class CudaBroadcastOneToAll : public Algorithm {
   void init(
       typename std::enable_if<
           std::is_same<U, CudaHostWorkspace<T>>::value,
-          typename U::Pointer>::type* = 0);
+          typename U::Pointer>::type* = NULL);
 
   template <typename U = W>
   void init(
       typename std::enable_if<
           std::is_same<U, CudaDeviceWorkspace<T>>::value,
-          typename U::Pointer>::type* = 0);
+          typename U::Pointer>::type* = NULL);
 
   std::vector<CudaDevicePointer<T>> devicePtrs_;
   std::vector<CudaStream> streams_;


### PR DESCRIPTION
Summary:
`nullptr` is preferable to `0` or `NULL`. Let's use it everywhere so we can enable `-Wzero-as-null-pointer-constant`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D70818154


