### PR TITLE
Fix deprecated use of 0/NULL in gloo/cuda_broadcast_one_to_all.h + 1

### DIFF
--- a/gloo/cuda_broadcast_one_to_all.h
+++ b/gloo/cuda_broadcast_one_to_all.h
@@ -36,13 +36,13 @@ class CudaBroadcastOneToAll : public Algorithm {
   void init(
       typename std::enable_if<
           std::is_same<U, CudaHostWorkspace<T>>::value,
-          typename U::Pointer>::type* = NULL);
+          typename U::Pointer>::type* = nullptr);
 
   template <typename U = W>
   void init(
       typename std::enable_if<
           std::is_same<U, CudaDeviceWorkspace<T>>::value,
-          typename U::Pointer>::type* = NULL);
+          typename U::Pointer>::type* = nullptr);
 
   std::vector<CudaDevicePointer<T>> devicePtrs_;
   std::vector<CudaStream> streams_;


### PR DESCRIPTION
Summary:
`nullptr` is typesafe. `0` and `NULL` are not. In the future, only `nullptr` will be allowed.

This diff helps us embrace the future _now_ in service of enabling `-Wzero-as-null-pointer-constant`.

Differential Revision: D71284808


