### PR TITLE
gloo/transport/tcp/loop: better memory management and shutdown

### DIFF
--- a/gloo/test/tcp_test.cc
+++ b/gloo/test/tcp_test.cc
@@ -17,7 +17,7 @@ TEST(TcpTest, ConnectTimeout) {
   // Use bad address
   auto remote = Address("::1", 10);
   auto timeout = std::chrono::milliseconds(100);
-  auto fn = [&](std::shared_ptr<Socket>, const Error& e) {
+  auto fn = [&](Loop&, std::shared_ptr<Socket>, const Error& e) {
     std::lock_guard<std::mutex> lock(m);
     done = true;
     cv.notify_all();
@@ -25,7 +25,7 @@ TEST(TcpTest, ConnectTimeout) {
     EXPECT_TRUE(e);
     EXPECT_TRUE(dynamic_cast<const TimeoutError*>(&e));
   };
-  connectLoop(loop, remote, 0, 5, timeout, std::move(fn));
+  connectLoop(*loop, remote, 0, 5, timeout, std::move(fn));
 
   std::unique_lock<std::mutex> lock(m);
   cv.wait(lock, [&] { return done; });

--- a/gloo/transport/tcp/helpers.cc
+++ b/gloo/transport/tcp/helpers.cc
@@ -5,15 +5,15 @@ namespace transport {
 namespace tcp {
 
 void connectLoop(
-    std::shared_ptr<Loop> loop,
+    Loop& loop,
     const Address& remote,
     const int rank,
     const int size,
     std::chrono::milliseconds timeout,
     typename ConnectOperation::callback_t fn) {
   auto x = std::make_shared<ConnectOperation>(
-      std::move(loop), remote, rank, size, timeout, std::move(fn));
-  x->run();
+      remote, rank, size, timeout, std::move(fn));
+  x->run(loop);
 }
 
 } // namespace tcp

--- a/gloo/transport/tcp/listener.cc
+++ b/gloo/transport/tcp/listener.cc
@@ -40,7 +40,7 @@ Listener::~Listener() {
   }
 }
 
-void Listener::handleEvents(int /* unused */) {
+void Listener::handleEvents(Loop& loop, int /* unused */) {
   std::lock_guard<std::mutex> guard(mutex_);
 
   for (;;) {
@@ -59,7 +59,7 @@ void Listener::handleEvents(int /* unused */) {
 
     // Read sequence number.
     read<sequence_number_t>(
-        loop_,
+        loop,
         sock,
         [this](
             std::shared_ptr<Socket> socket,

--- a/gloo/transport/tcp/listener.h
+++ b/gloo/transport/tcp/listener.h
@@ -38,7 +38,7 @@ class Listener final : public Handler {
 
   ~Listener() override;
 
-  void handleEvents(int events) override;
+  void handleEvents(Loop& loop, int events) override;
 
   Address nextAddress();
 

--- a/gloo/transport/tcp/pair.cc
+++ b/gloo/transport/tcp/pair.cc
@@ -635,7 +635,7 @@ void Pair::handleRemotePendingRecv(const Op& op) {
   mutator.pushRemotePendingRecv();
 }
 
-void Pair::handleEvents(int events) {
+void Pair::handleEvents(Loop& /*loop*/, int events) {
   // Try to acquire the pair's lock so the device thread (the thread
   // that ends up calling handleEvents) can mutate the tx and rx op
   // fields of this instance. If the lock cannot be acquired that

--- a/gloo/transport/tcp/pair.h
+++ b/gloo/transport/tcp/pair.h
@@ -139,7 +139,7 @@ class Pair : public ::gloo::transport::Pair, public Handler {
       size_t offset,
       size_t nbytes);
 
-  void handleEvents(int events) override;
+  void handleEvents(Loop& loop, int events) override;
 
   void close() override;
 


### PR DESCRIPTION
Summary:
This overhauls how we schedule async operations on the tcp Loop. 

These changes greatly simplifies the memory management and simplifies the shutdown logic since memory ownership is better tied to epoll usage and relies less on shared_ptr copies everywhere to work around it.

This makes a few major changes:

* adds a new `registerDescriptor` method to Loop that provides a shared_ptr. This method will track the lifetime of the provided Handler and will release it when the epoll handle is updated/deleted.
* Make `Handler::handleEvents` signature provide a `Loop&` reference so all objects don't need to hold a shared_ptr to the loop.
* Update `helpers.h` to not manage it's own lifetime (instead using registerDescriptor shared_ptr support) and also not hold a shared_ptr to `Loop`.
* Introduces a new `shutdown()` method that allows the loop to gracefully shutdown all operations prior to destruction. This simplifies teardown on error since there a few places where handlers (Device) are managed with raw pointers. This isn't used outside of Loop currently but will be in a follow up PR.

Differential Revision: D72080276


