### PR TITLE
Back out "Revert D69698406: gloo: async lazy connect"

### DIFF
--- a/gloo/test/allgather_test.cc
+++ b/gloo/test/allgather_test.cc
@@ -167,6 +167,11 @@ TEST_F(AllgatherNewTest, TestTimeout) {
     AllgatherOptions opts(context);
     opts.setInput(input.getPointer(), 1);
     opts.setOutput(output.getPointer(), context->size);
+
+    // Run one operation first so we're measuring the operation timeout not
+    // connection timeout.
+    allgather(opts);
+
     opts.setTimeout(std::chrono::milliseconds(10));
     if (context->rank == 0) {
       try {

--- a/gloo/test/allgatherv_test.cc
+++ b/gloo/test/allgatherv_test.cc
@@ -95,6 +95,11 @@ TEST_F(AllgathervTest, TestTimeout) {
     std::vector<size_t> counts({1, 1});
     AllgathervOptions opts(context);
     opts.setOutput(output.getPointer(), counts);
+
+    // Run one operation first so we're measuring the operation timeout not
+    // connection timeout.
+    allgatherv(opts);
+
     opts.setTimeout(std::chrono::milliseconds(10));
     if (context->rank == 0) {
       try {

--- a/gloo/test/allreduce_test.cc
+++ b/gloo/test/allreduce_test.cc
@@ -389,6 +389,11 @@ TEST_F(AllreduceNewTest, TestTimeout) {
     AllreduceOptions opts(context);
     opts.setOutputs(outputs.getPointers(), 1);
     opts.setReduceFunction(getFunction<uint64_t>());
+
+    // Run one operation first so we're measuring the operation timeout not
+    // connection timeout.
+    allreduce(opts);
+
     opts.setTimeout(std::chrono::milliseconds(10));
     if (context->rank == 0) {
       try {

--- a/gloo/test/barrier_test.cc
+++ b/gloo/test/barrier_test.cc
@@ -127,12 +127,18 @@ INSTANTIATE_TEST_CASE_P(
 TEST_F(BarrierNewTest, TestTimeout) {
   spawn(Transport::TCP, 2, [&](std::shared_ptr<Context> context) {
     BarrierOptions opts(context);
+
+    // Run barrier first so we're measuring the barrier timeout not connection
+    // timeout.
+    barrier(opts);
+
     opts.setTimeout(std::chrono::milliseconds(10));
     if (context->rank == 0) {
       try {
         barrier(opts);
         FAIL() << "Expected exception to be thrown";
       } catch (::gloo::IoException& e) {
+        std::cerr << e.what() << std::endl;
         ASSERT_NE(std::string(e.what()).find("Timed out"), std::string::npos);
       }
     }

--- a/gloo/test/base_test.cc
+++ b/gloo/test/base_test.cc
@@ -17,6 +17,7 @@ const char* kDefaultDevice = "localhost";
 // Transports that instantiated algorithms can be tested against.
 const std::vector<Transport> kTransportsForClassAlgorithms = {
     Transport::TCP,
+    Transport::TCP_LAZY,
 #if GLOO_HAVE_TRANSPORT_TCP_TLS
     Transport::TCP_TLS,
 #endif
@@ -27,6 +28,7 @@ const std::vector<Transport> kTransportsForClassAlgorithms = {
 // preferred over the instantiated style.
 const std::vector<Transport> kTransportsForFunctionAlgorithms = {
     Transport::TCP,
+    Transport::TCP_LAZY,
 #if GLOO_HAVE_TRANSPORT_TCP_TLS
     Transport::TCP_TLS,
 #endif
@@ -37,6 +39,8 @@ std::shared_ptr<::gloo::transport::Device> createDevice(Transport transport) {
 #if GLOO_HAVE_TRANSPORT_TCP
   if (transport == Transport::TCP) {
     return ::gloo::transport::tcp::CreateDevice(kDefaultDevice);
+  } else if (transport == Transport::TCP_LAZY) {
+    return ::gloo::transport::tcp::CreateLazyDevice(kDefaultDevice);
   }
 #endif
 #if GLOO_HAVE_TRANSPORT_TCP_TLS

--- a/gloo/test/base_test.h
+++ b/gloo/test/base_test.h
@@ -59,6 +59,7 @@ class Barrier {
 
 enum Transport {
   TCP,
+  TCP_LAZY,
 #if GLOO_HAVE_TRANSPORT_TCP_TLS
   TCP_TLS,
 #endif

--- a/gloo/test/broadcast_test.cc
+++ b/gloo/test/broadcast_test.cc
@@ -182,6 +182,11 @@ TEST_F(BroadcastTest, TestTimeout) {
     BroadcastOptions opts(context);
     opts.setOutput(output.getPointer(), 1);
     opts.setRoot(0);
+
+    // Run one operation first so we're measuring the operation timeout not
+    // connection timeout.
+    broadcast(opts);
+
     opts.setTimeout(std::chrono::milliseconds(10));
     if (context->rank == 0) {
       try {

--- a/gloo/test/gather_test.cc
+++ b/gloo/test/gather_test.cc
@@ -76,6 +76,11 @@ TEST_F(GatherTest, TestTimeout) {
     opts.setInput(input.getPointer(), 1);
     opts.setOutput(output.getPointer(), context->size);
     opts.setRoot(0);
+
+    // Run one operation first so we're measuring the operation timeout not
+    // connection timeout.
+    gather(opts);
+
     opts.setTimeout(std::chrono::milliseconds(10));
     if (context->rank == 0) {
       try {

--- a/gloo/test/gatherv_test.cc
+++ b/gloo/test/gatherv_test.cc
@@ -106,6 +106,11 @@ TEST_F(GathervTest, TestTimeout) {
     opts.setRoot(0);
     opts.setInput(input.getPointer(), 1);
     opts.setOutput(output.getPointer(), counts);
+
+    // Run one operation first so we're measuring the operation timeout not
+    // connection timeout.
+    gatherv(opts);
+
     opts.setTimeout(std::chrono::milliseconds(10));
     if (context->rank == 0) {
       try {

--- a/gloo/test/multiproc_test.h
+++ b/gloo/test/multiproc_test.h
@@ -102,9 +102,29 @@ class MultiProcWorker {
     auto device = createDevice(transport);
     context->setTimeout(std::chrono::milliseconds(kMultiProcTimeout));
     context->connectFullMesh(store_, device);
+
+    // Wait for all workers to be ready
+    ringBarrier(context);
+
     device.reset();
     sem_post(semaphore_);
     fn(std::move(context));
+  }
+
+  void ringBarrier(std::shared_ptr<::gloo::rendezvous::Context>& context) {
+    int sendScratch = 0;
+    int recvScratch = 0;
+    auto sendBuf =
+        context->createUnboundBuffer(&sendScratch, sizeof(sendScratch));
+    auto recvBuf =
+        context->createUnboundBuffer(&recvScratch, sizeof(recvScratch));
+    const auto leftRank = (context->size + context->rank - 1) % context->size;
+    const auto rightRank = (context->rank + 1) % context->size;
+
+    sendBuf->send(leftRank, 0);
+    recvBuf->recv(rightRank, 0);
+    sendBuf->waitSend();
+    recvBuf->waitRecv();
   }
 
  protected:

--- a/gloo/test/reduce_test.cc
+++ b/gloo/test/reduce_test.cc
@@ -101,6 +101,11 @@ TEST_F(ReduceTest, TestTimeout) {
     opts.setOutput(outputs.getPointer(), 1);
     opts.setRoot(0);
     opts.setReduceFunction(getFunction<uint64_t>());
+
+    // Run one operation first so we're measuring the operation timeout not
+    // connection timeout.
+    reduce(opts);
+
     opts.setTimeout(std::chrono::milliseconds(10));
     if (context->rank == 0) {
       try {

--- a/gloo/test/scatter_test.cc
+++ b/gloo/test/scatter_test.cc
@@ -72,6 +72,11 @@ TEST_F(ScatterTest, TestTimeout) {
     opts.setInputs(input.getPointers(), 1);
     opts.setOutput(output.getPointer(), 1);
     opts.setRoot(0);
+
+    // Run one operation first so we're measuring the operation timeout not
+    // connection timeout.
+    scatter(opts);
+
     opts.setTimeout(std::chrono::milliseconds(10));
     if (context->rank == 0) {
       try {

--- a/gloo/test/tcp_test.cc
+++ b/gloo/test/tcp_test.cc
@@ -8,7 +8,7 @@ namespace transport {
 namespace tcp {
 
 TEST(TcpTest, ConnectTimeout) {
-  auto loop = std::make_shared<Loop>();
+  Loop loop;
 
   std::mutex m;
   std::condition_variable cv;
@@ -25,7 +25,7 @@ TEST(TcpTest, ConnectTimeout) {
     EXPECT_TRUE(e);
     EXPECT_TRUE(dynamic_cast<const TimeoutError*>(&e));
   };
-  connectLoop(*loop, remote, 0, 5, timeout, std::move(fn));
+  connectLoop(loop, remote, 0, 5, timeout, std::move(fn));
 
   std::unique_lock<std::mutex> lock(m);
   cv.wait(lock, [&] { return done; });

--- a/gloo/transport/tcp/context.cc
+++ b/gloo/transport/tcp/context.cc
@@ -27,9 +27,18 @@ namespace tcp {
 constexpr int kDefaultBatchSize = 128;
 
 Context::Context(std::shared_ptr<Device> device, int rank, int size)
-    : ::gloo::transport::Context(rank, size), device_(std::move(device)) {}
+    : ::gloo::transport::Context(rank, size), device_(std::move(device)) {
+  connecting_.resize(size);
+}
 
 Context::~Context() {
+  if (device_->isLazyInit()) {
+    // We need to shutdown the loop thread prior to freeing the pairs as
+    // connection callbacks may be called after we free the pairs leading to
+    // invalid memory accesses.
+    device_->shutdown();
+  }
+
   // Pairs refer to device by raw pointer.
   // Ensure they are destructed before the device.
   pairs_.clear();
@@ -50,8 +59,6 @@ void Context::createAndConnectAllPairs(std::shared_ptr<IStore> store) {
   // it's not super straightforward so left for folks having more bandwidth
   // later on.
 
-  int localRank = 0;
-  bool localRankSet = false;
   auto localHostName = getHostname();
   bool useRankAsSeqNum = useRankAsSeqNumber();
 
@@ -61,7 +68,7 @@ void Context::createAndConnectAllPairs(std::shared_ptr<IStore> store) {
   std::vector<ssize_t> pairIdentifiers;
   for (int i = 0; i < size; i++) {
     const auto& pair = createPair(i, useRankAsSeqNum);
-    if (!useRankAsSeqNum) {
+    if (!useRankAsSeqNum && !device_->isLazyInit()) {
       // Need to preserve the order of the pair identifiers if we are not using
       // the rank as seq number
       pairIdentifiers.emplace_back(
@@ -88,65 +95,101 @@ void Context::createAndConnectAllPairs(std::shared_ptr<IStore> store) {
       localHostName, deviceAddress.bytes(), std::move(pairIdentifiers));
   store->set(std::to_string(rank), currentRankInfo.bytes());
 
-  std::vector<std::vector<char>> remoteRankInfos;
-  int key = 0;
-  if (isStoreExtendedApiEnabled() && store->has_v2_support()) {
-    auto sizeRemaining = size;
-    while (sizeRemaining > 0) {
-      const auto batchKeys = std::min(kDefaultBatchSize, sizeRemaining);
-      std::vector<std::string> keys(batchKeys);
-      std::generate_n(
-          keys.begin(), batchKeys, [&] { return std::to_string(key++); });
-      const auto& batchRemoteInfos = store->multi_get(keys);
-      remoteRankInfos.insert(
-          remoteRankInfos.end(),
-          batchRemoteInfos.begin(),
-          batchRemoteInfos.end());
-      sizeRemaining -= batchKeys;
-    }
-  } else {
-    std::generate_n(std::back_inserter(remoteRankInfos), size, [&] {
-      const auto& keyStr = std::to_string(key++);
-      return store->wait_get(keyStr, getTimeout());
-    });
-  }
+  store_ = store;
 
-  // Connect every pair
-  for (int i = 0; i < size; i++) {
-    if (i == rank) {
-      // at this point we have enumerated all the ranks located on this host
-      // up to the current rank, so the current `localRank` number is
-      // what we'll set to the pairs.
-      localRankSet = true;
-      // We are not going to connect self.
-      continue;
+  if (!device_->isLazyInit()) {
+    int localRank = 0;
+    bool localRankSet = false;
+    std::vector<std::vector<char>> remoteRankInfos;
+    int key = 0;
+    if (isStoreExtendedApiEnabled() && store->has_v2_support()) {
+      auto sizeRemaining = size;
+      while (sizeRemaining > 0) {
+        const auto batchKeys = std::min(kDefaultBatchSize, sizeRemaining);
+        std::vector<std::string> keys(batchKeys);
+        std::generate_n(
+            keys.begin(), batchKeys, [&] { return std::to_string(key++); });
+        const auto& batchRemoteInfos = store->multi_get(keys);
+        remoteRankInfos.insert(
+            remoteRankInfos.end(),
+            batchRemoteInfos.begin(),
+            batchRemoteInfos.end());
+        sizeRemaining -= batchKeys;
+      }
+    } else {
+      std::generate_n(std::back_inserter(remoteRankInfos), size, [&] {
+        const auto& keyStr = std::to_string(key++);
+        return store->wait_get(keyStr, getTimeout());
+      });
     }
 
-    Rank remoteRankInfo(remoteRankInfos[i]);
+    // Connect every pair
+    for (int i = 0; i < size; i++) {
+      if (i == rank) {
+        // at this point we have enumerated all the ranks located on this host
+        // up to the current rank, so the current `localRank` number is
+        // what we'll set to the pairs.
+        localRankSet = true;
+        // We are not going to connect self.
+        continue;
+      }
 
-    if (!localRankSet && remoteRankInfo.hostname == localHostName) {
-      ++localRank;
+      Rank remoteRankInfo(remoteRankInfos[i]);
+
+      if (!localRankSet && remoteRankInfo.hostname == localHostName) {
+        ++localRank;
+      }
+
+      const auto& pair = pairs_[i];
+      auto remoteDeviceAddr =
+          Address(remoteRankInfo.addressBytes).getSockaddr();
+      auto remoteAddr = Address(
+          remoteDeviceAddr,
+          useRankAsSeqNum ? (sequence_number_t)rank
+                          : remoteRankInfo.pairIdentifiers[rank]);
+      pair->connect(remoteAddr.bytes());
+      connecting_[i] = true;
     }
 
-    const auto& pair = getPair(i);
-    auto remoteDeviceAddr = Address(remoteRankInfo.addressBytes).getSockaddr();
-    auto remoteAddr = Address(
-        remoteDeviceAddr,
-        useRankAsSeqNum ? (sequence_number_t)rank
-                        : remoteRankInfo.pairIdentifiers[rank]);
-    pair->connect(remoteAddr.bytes());
-  }
-
-  // Set the local rank info for all mesh pairs involving current rank
-  for (int i = 0; i < size; i++) {
-    if (i == rank) {
-      continue;
+    // Set the local rank info for all mesh pairs involving current rank
+    for (int i = 0; i < size; i++) {
+      if (i == rank) {
+        continue;
+      }
+      const auto& pair = getPair(i);
+      pair->setLocalRank(localRank);
     }
-    const auto& pair = getPair(i);
-    pair->setLocalRank(localRank);
   }
 
   printConnectivityInfo();
+}
+
+std::unique_ptr<transport::Pair>& Context::getPair(int rank) {
+  auto& pair = pairs_[rank];
+
+  if (!store_) {
+    // Manual context creation without store to bootstrap.
+    return pair;
+  }
+
+  // don't connect to self
+  if (rank == this->rank) {
+    return pair;
+  }
+
+  if (!connecting_[rank]) {
+    connecting_[rank] = true;
+
+    const auto& keyStr = std::to_string(rank);
+    auto remoteRankInfoBytes = store_->wait_get(keyStr, getTimeout());
+
+    Rank remoteRankInfo(remoteRankInfoBytes);
+
+    auto remoteDeviceAddr = Address(remoteRankInfo.addressBytes).getSockaddr();
+    auto remoteAddr = Address(remoteDeviceAddr, this->rank);
+    pair->connect(remoteAddr.bytes());
+  }
+  return pair;
 }
 
 std::unique_ptr<transport::Pair>& Context::createPair(int rank) {
@@ -219,6 +262,11 @@ void Context::recvFromAny(
     size_t offset,
     size_t nbytes,
     std::vector<int> srcRanks) {
+  // Ensure all connections are established.
+  for (auto rank : srcRanks) {
+    getPair(rank);
+  }
+
   for (;;) {
     // Find rank of pair we can attempt a recv from
     auto rank = recvFromAnyFindRank(buf, slot, offset, nbytes, srcRanks);

--- a/gloo/transport/tcp/context.h
+++ b/gloo/transport/tcp/context.h
@@ -43,12 +43,16 @@ class Context : public ::gloo::transport::Context,
       int rank,
       bool useRankAsSeqNumber);
 
+  virtual std::unique_ptr<transport::Pair>& getPair(int rank) override;
+
   std::unique_ptr<transport::UnboundBuffer> createUnboundBuffer(
       void* ptr,
       size_t size) override;
 
  protected:
   std::shared_ptr<Device> device_;
+  std::shared_ptr<IStore> store_{nullptr};
+  std::vector<bool> connecting_;
 
   using pendingRecvTuple = std::tuple<
       WeakNonOwningPtr<UnboundBuffer>,

--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -13,6 +13,7 @@
 #include <netinet/in.h>
 #include <string.h>
 #include <array>
+#include <iostream>
 
 #include "gloo/common/error.h"
 #include "gloo/common/linux.h"
@@ -156,7 +157,14 @@ struct attr CreateDeviceAttr(const struct attr& src) {
 }
 
 std::shared_ptr<transport::Device> CreateDevice(const struct attr& src) {
-  auto device = std::make_shared<Device>(CreateDeviceAttr(src));
+  auto device =
+      std::make_shared<Device>(CreateDeviceAttr(src), /*lazyInit=*/false);
+  return std::shared_ptr<transport::Device>(device);
+}
+
+std::shared_ptr<transport::Device> CreateLazyDevice(const struct attr& src) {
+  auto device =
+      std::make_shared<Device>(CreateDeviceAttr(src), /*lazyInit=*/true);
   return std::shared_ptr<transport::Device>(device);
 }
 
@@ -209,15 +217,23 @@ const std::string sockaddrToInterfaceName(const struct attr& attr) {
   return iface;
 }
 
-Device::Device(const struct attr& attr)
+Device::Device(const struct attr& attr, bool lazyInit)
     : attr_(attr),
+      lazyInit_(lazyInit),
       loop_(std::make_shared<Loop>()),
       listener_(std::make_shared<Listener>(loop_, attr)),
       interfaceName_(sockaddrToInterfaceName(attr_)),
       interfaceSpeedMbps_(getInterfaceSpeedByName(interfaceName_)),
       pciBusID_(interfaceToBusID(interfaceName_)) {}
 
-Device::~Device() {}
+void Device::shutdown() {
+  loop_->shutdown();
+  listener_->shutdown();
+}
+
+Device::~Device() {
+  shutdown();
+}
 
 std::string Device::str() const {
   std::stringstream ss;

--- a/gloo/transport/tcp/device.h
+++ b/gloo/transport/tcp/device.h
@@ -29,6 +29,7 @@ namespace tcp {
 struct attr CreateDeviceAttr(const struct attr& src);
 
 std::shared_ptr<::gloo::transport::Device> CreateDevice(const struct attr&);
+std::shared_ptr<::gloo::transport::Device> CreateLazyDevice(const struct attr&);
 
 // Forward declarations
 class Pair;
@@ -37,7 +38,7 @@ class Buffer;
 class Device : public ::gloo::transport::Device,
                public std::enable_shared_from_this<Device> {
  public:
-  explicit Device(const struct attr& attr);
+  explicit Device(const struct attr& attr, bool lazyInit);
   virtual ~Device();
 
   virtual std::string str() const override;
@@ -57,8 +58,15 @@ class Device : public ::gloo::transport::Device,
   // one side is the connection initiator and the other is the listener.
   bool isInitiator(const Address& local, const Address& remote) const;
 
+  void shutdown();
+
+  bool isLazyInit() {
+    return lazyInit_;
+  }
+
  protected:
   const struct attr attr_;
+  const bool lazyInit_;
 
   // Return a new `Address` instance.
   //

--- a/gloo/transport/tcp/helpers.h
+++ b/gloo/transport/tcp/helpers.h
@@ -47,7 +47,7 @@ class ReadValueOperation final
     auto rv = socket_->read(&t_, sizeof(t_));
     if (rv == -1) {
       fn_(socket_,
-          SystemError("read", errno, socket_->peerName()),
+          SystemError("read", errno, socket_->safePeerName()),
           std::move(t_));
       return;
     }
@@ -55,7 +55,7 @@ class ReadValueOperation final
     // Check for short read (assume we can read in a single call).
     if (rv < sizeof(t_)) {
       fn_(socket_,
-          ShortReadError(rv, sizeof(t_), socket_->peerName()),
+          ShortReadError(rv, sizeof(t_), socket_->safePeerName()),
           std::move(t_));
       return;
     }
@@ -104,13 +104,13 @@ class WriteValueOperation final
     // Write T.
     auto rv = socket_->write(&t_, sizeof(t_));
     if (rv == -1) {
-      fn_(socket_, SystemError("write", errno, socket_->peerName()));
+      fn_(socket_, SystemError("write", errno, socket_->safePeerName()));
       return;
     }
 
     // Check for short write (assume we can write in a single call).
     if (rv < sizeof(t_)) {
-      fn_(socket_, ShortWriteError(rv, sizeof(t_), socket_->peerName()));
+      fn_(socket_, ShortWriteError(rv, sizeof(t_), socket_->safePeerName()));
       return;
     }
 

--- a/gloo/transport/tcp/listener.h
+++ b/gloo/transport/tcp/listener.h
@@ -49,10 +49,14 @@ class Listener final : public Handler {
   // even if the connection is already available.
   void waitForConnection(sequence_number_t seq, connect_callback_t fn);
 
+  void shutdown();
+
  private:
   std::mutex mutex_;
   std::shared_ptr<Loop> loop_;
   std::shared_ptr<Socket> listener_;
+  std::shared_ptr<std::atomic<bool>> closed_{
+      std::make_shared<std::atomic<bool>>(false)};
 
   // Address of this listener and the sequence number for the next
   // connection. Sequence numbers are written by a peer right after

--- a/gloo/transport/tcp/pair.h
+++ b/gloo/transport/tcp/pair.h
@@ -16,6 +16,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <tuple>
@@ -313,7 +314,7 @@ class Pair : public ::gloo::transport::Pair, public Handler {
       bool useTimeout);
 
   // Helper function to assert the current state is `CONNECTED`.
-  virtual void verifyConnected();
+  virtual void verifyConnected(std::unique_lock<std::mutex>& lock);
 
   // Throws if an exception if set.
   void throwIfException();

--- a/gloo/transport/tcp/socket.cc
+++ b/gloo/transport/tcp/socket.cc
@@ -178,6 +178,14 @@ Address Socket::peerName() const {
   return Address::fromPeerName(fd_);
 }
 
+Address Socket::safePeerName() const {
+  try {
+    return Address::fromPeerName(fd_);
+  } catch (const EnforceNotMet&) {
+    return Address();
+  }
+}
+
 } // namespace tcp
 } // namespace transport
 } // namespace gloo

--- a/gloo/transport/tcp/socket.h
+++ b/gloo/transport/tcp/socket.h
@@ -85,6 +85,9 @@ class Socket final : public std::enable_shared_from_this<Socket> {
   // Return address for getpeername(2).
   Address peerName() const;
 
+  // Return address for getpeername(2) if possible, else an empty Address.
+  Address safePeerName() const;
+
  private:
   int fd_;
 

--- a/gloo/transport/tcp/tls/device.cc
+++ b/gloo/transport/tcp/tls/device.cc
@@ -36,7 +36,7 @@ Device::Device(
     std::string cert_file,
     std::string ca_file,
     std::string ca_path)
-    : ::gloo::transport::tcp::Device(attr),
+    : ::gloo::transport::tcp::Device(attr, /*lazyInit=*/false),
       pkey_file_(std::move(pkey_file)),
       cert_file_(std::move(cert_file)),
       ca_file_(std::move(ca_file)),

--- a/gloo/transport/tcp/tls/pair.cc
+++ b/gloo/transport/tcp/tls/pair.cc
@@ -298,8 +298,8 @@ void Pair::waitUntilConnected(
   }
 }
 
-void Pair::verifyConnected() {
-  ::gloo::transport::tcp::Pair::verifyConnected();
+void Pair::verifyConnected(std::unique_lock<std::mutex>& lock) {
+  ::gloo::transport::tcp::Pair::verifyConnected(lock);
   GLOO_ENFORCE(
       is_ssl_connected_,
       "Pair is not SSL connected (",

--- a/gloo/transport/tcp/tls/pair.h
+++ b/gloo/transport/tcp/tls/pair.h
@@ -45,7 +45,7 @@ class Pair : public ::gloo::transport::tcp::Pair {
       std::unique_lock<std::mutex>& lock,
       bool useTimeout);
 
-  void verifyConnected() override;
+  void verifyConnected(std::unique_lock<std::mutex>& lock) override;
 
   void changeState(state nextState) noexcept override;
 


### PR DESCRIPTION
Summary:
Original commit changeset: 4cfad1d7b700

Original Phabricator Diff: D69698406
***
gloo: only shutdown device when async

See original PR for details and test plan: D69698406

This extends that PR with one small change to avoid shutting down Device when using non-async mode to preserve backwards compatibility for caffe2.

Reviewed By: fduwjj

Differential Revision: D72425729


