### PR TITLE
tcp/context: use mutex to avoid race condition when multiple operations are running

### DIFF
--- a/gloo/transport/tcp/context.cc
+++ b/gloo/transport/tcp/context.cc
@@ -177,6 +177,8 @@ std::unique_ptr<transport::Pair>& Context::getPair(int rank) {
     return pair;
   }
 
+  std::lock_guard<std::mutex> lock(m_);
+
   if (!connecting_[rank]) {
     connecting_[rank] = true;
 
@@ -187,6 +189,7 @@ std::unique_ptr<transport::Pair>& Context::getPair(int rank) {
 
     auto remoteDeviceAddr = Address(remoteRankInfo.addressBytes).getSockaddr();
     auto remoteAddr = Address(remoteDeviceAddr, this->rank);
+    // Actual connection happens asynchronously.
     pair->connect(remoteAddr.bytes());
   }
   return pair;

--- a/gloo/transport/tcp/context.h
+++ b/gloo/transport/tcp/context.h
@@ -52,6 +52,10 @@ class Context : public ::gloo::transport::Context,
  protected:
   std::shared_ptr<Device> device_;
   std::shared_ptr<IStore> store_{nullptr};
+
+  // Protects the connection states to avoid race conditions.
+  std::mutex m_;
+  // Whether or not connection has been started for this peer.
   std::vector<bool> connecting_;
 
   using pendingRecvTuple = std::tuple<


### PR DESCRIPTION
When multiple operations are running we may end up calling `getPair` from multiple threads simultaneously. This causes a crash due to duplicate connect calls and state modifications.

This does add an additional synchronization point but under most usage this should be very cheap as after the first connection we only check a single variable and return.

Test plan:

https://github.com/pytorch/pytorch/pull/150801