### PR TITLE
Include cstdlib header in common/utils.cc

### DIFF
--- a/gloo/common/utils.cc
+++ b/gloo/common/utils.cc
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cstdlib>
 #include <system_error>
 
 #ifdef _WIN32


### PR DESCRIPTION
This is required to use `getenv`.