### PR TITLE
Doing the proper error check after calling getaddrinfo

### DIFF
--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -96,7 +96,7 @@ static void lookupAddrForHostname(struct attr& attr) {
   int bind_errno = 0;
   std::string bind_addr;
   auto rv = getaddrinfo(attr.hostname.data(), nullptr, &hints, &result);
-  GLOO_ENFORCE_NE(rv, -1);
+  GLOO_ENFORCE_EQ(rv, 0);
   struct addrinfo* rp;
   for (rp = result; rp != nullptr; rp = rp->ai_next) {
     auto fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);


### PR DESCRIPTION
Summary:
Function `getaddrinfo()` is expected to return 0 on success and other error codes in case of failures as per the man page: https://fburl.com/tg3q11nw. However, current logic in `lookupAddrForHostname()` function is just checking for return value not equal to -1: https://fburl.com/code/wk7ztua9 for error check.This fix ensures that the return value of `getaddrinfo()` zero on suceessfull cases.

 {F1977470144}

Differential Revision: D73746837


