### PR TITLE
examples/looks_like_mpi: Fix build errors

### DIFF
--- a/gloo/examples/looks_like_mpi.cc
+++ b/gloo/examples/looks_like_mpi.cc
@@ -190,8 +190,9 @@ void init(const std::string& path) {
   const int size = atoi(getenv("SIZE"));
 
   // Initialize store
-  auto fileStore = gloo::rendezvous::FileStore(path);
-  auto prefixStore = gloo::rendezvous::PrefixStore(prefix, fileStore);
+  auto fileStore = std::make_shared<gloo::rendezvous::FileStore>(path);
+  auto prefixStore =
+      std::make_shared<gloo::rendezvous::PrefixStore>(prefix, fileStore);
 
   // Initialize device
   gloo::transport::tcp::attr attr;


### PR DESCRIPTION
Gloo is currently hitting two compilation issues when trying to compile examples/looks_like_mpi. These are addressed by two commits in this PR:
1. Fake-MPI functions have return type `int`, but don't return anything. Fix this by just always returning `MPI_SUCCESS` (`0`), since this example handles error cases with `ASSERT` statements.
2. The new `shared_ptr`-based API for gloo Stores (https://github.com/pytorch/gloo/commit/9ba706d63c59295e635a0a4a7fb2586dc2598afc) is not being used. Fixed by using the new API.