### PR TITLE
cleanup: Remove .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third-party/googletest"]
-	path = third-party/googletest
-	url = https://github.com/google/googletest.git


### PR DESCRIPTION
.gitmodules still contains the googletest module. This was added in 1bf61b8adcacd3646f6b53e1b2cf57117536d75a and 0f7b7b27b14a516f0dad21f110552bc5ae76764f. The third-party/googletest module link was removed in d7bc19075c840ae5eb899a8111cb4a2df0580fbe, but .gitmodules was not updated to remove it.

This commit removes .gitmodules, as the googletest module is no longer used, and no other modules are defined in the file.