### PR TITLE
ci/windows: bump libuv version and fix windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -38,15 +38,15 @@ jobs:
         run: conda info
       - name: Setup build environment
         run: |
-          conda create -n py376_build python=3.7.6
-          conda activate py376_build
+          conda create -n build python=3.12
+          conda activate build
           conda install cmake
       - name: Install libuv
         run: |
-          conda activate py376_build
-          curl https://dist.libuv.org/dist/v1.38.0/libuv-v1.38.0.tar.gz --output libuv-v1.38.0.tar.gz
-          tar xzvf libuv-v1.38.0.tar.gz
-          cd libuv-v1.38.0
+          conda activate build
+          curl https://dist.libuv.org/dist/v1.49.2/libuv-v1.49.2.tar.gz --output libuv-v1.49.2.tar.gz
+          tar xzvf libuv-v1.49.2.tar.gz
+          cd libuv-v1.49.2
           mkdir -p build
           cd build
           mkdir -p ${{ env.libuv_path }}
@@ -54,7 +54,7 @@ jobs:
           msbuild INSTALL.vcxproj
       - name: Install googletest
         run: |
-          conda activate py376_build
+          conda activate build
           curl -L https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz `
             --output googletest-1.15.2.tar.gz
           tar xzvf googletest-1.15.2.tar.gz
@@ -70,7 +70,7 @@ jobs:
           msbuild INSTALL.vcxproj
       - name: Build
         run: |
-          conda activate py376_build
+          conda activate build
           git submodule sync
           git submodule update --init --recursive
           mkdir -p build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,9 @@ if(MSVC)
   message(STATUS "Set USE_NCCL OFF")
   set(USE_RCCL OFF)
   message(STATUS "Set USE_RCCL OFF")
-  set(USE_LIBUV OFF)
-  message(STATUS "Set USE_LIBUV OFF")
-  # message(STATUS "Only USE_LIBUV is supported on Windows")
+  set(USE_LIBUV ON)
+  message(STATUS "Set USE_LIBUV ON")
+  message(STATUS "Only USE_LIBUV is supported on Windows")
 
   if(BUILD_BENCHMARK)
     message(FATAL_ERROR "BUILD_BENCHMARK is not supported on Windows yet")
@@ -117,8 +117,9 @@ include_directories(${PROJECT_BINARY_DIR})
 
 # Compiler flags
 
+set (CMAKE_CXX_STANDARD 17)
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
 # Recurse into main project directory

--- a/gloo/common/logging.h
+++ b/gloo/common/logging.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <climits>
+#include <cstdint>
 #include <exception>
 #include <functional>
 #include <iostream>
@@ -18,14 +19,20 @@
 #include "gloo/common/error.h"
 #include "gloo/common/string.h"
 
+#ifdef _WIN32
+#ifdef ERROR
+#undef ERROR
+#endif
+#endif
+
 namespace gloo {
 
-enum LogLevel {
-  ERROR,
-  WARN,
-  INFO,
-  DEBUG,
-  UNSET,
+enum class LogLevel : std::int8_t {
+  ERROR = 0,
+  WARN = 1,
+  INFO = 2,
+  DEBUG = 3,
+  UNSET = -1,
 };
 
 LogLevel logLevel();

--- a/gloo/transport/uv/device.cc
+++ b/gloo/transport/uv/device.cc
@@ -304,7 +304,7 @@ void Device::connectAsListener(
     const Address& local,
     std::chrono::milliseconds timeout,
     ConnectCallback connectCallback) {
-  defer([=, this] {
+  defer([=] {
     decltype(pendingConnections_)::mapped_type pendingConnection;
 
     // Find pending connection, or stash the connect callback.
@@ -360,7 +360,7 @@ void Device::connectAsInitiator(
     const Address& remote,
     std::chrono::milliseconds timeout,
     ConnectCallback fn) {
-  defer([=, this] {
+  defer([=] {
     auto tcp = loop_->resource<libuv::TCP>();
     auto timer = loop_->resource<libuv::Timer>();
 
@@ -458,7 +458,7 @@ void Device::listenCallback() {
 
   // Wait for remote side to write sequence number.
   handle->once<libuv::ReadEvent>(
-      [=, this](const libuv::ReadEvent& event, libuv::TCP& handle) {
+      [=](const libuv::ReadEvent& event, libuv::TCP& handle) {
         // Sequence number has been read. Either there is an existing
         // connection callback for this sequence number, or we'll hold
         // on to the handle while we wait for the pair to pass a

--- a/gloo/transport/uv/pair.cc
+++ b/gloo/transport/uv/pair.cc
@@ -554,7 +554,7 @@ void Pair::closeWhileHoldingPairLock() {
           state_, CONNECTING, "Cannot close pair while waiting on connection");
       break;
     case CONNECTED:
-      device_->defer([=, this] { this->handle_->close(); });
+      device_->defer([=] { this->handle_->close(); });
       state_ = CLOSING;
       break;
     case CLOSING:


### PR DESCRIPTION
This fixes the windows build by bumping the libuv version to be compatible with newer versions of cmake.

https://github.com/pytorch/gloo/actions/runs/18698446504/job/53321707849