### PR TITLE
Enable `-Wdeprecated-this-capture` in gloo/PACKAGE +1

### DIFF
--- a/gloo/transport/uv/device.cc
+++ b/gloo/transport/uv/device.cc
@@ -304,7 +304,7 @@ void Device::connectAsListener(
     const Address& local,
     std::chrono::milliseconds timeout,
     ConnectCallback connectCallback) {
-  defer([=] {
+  defer([=, this] {
     decltype(pendingConnections_)::mapped_type pendingConnection;
 
     // Find pending connection, or stash the connect callback.
@@ -360,7 +360,7 @@ void Device::connectAsInitiator(
     const Address& remote,
     std::chrono::milliseconds timeout,
     ConnectCallback fn) {
-  defer([=] {
+  defer([=, this] {
     auto tcp = loop_->resource<libuv::TCP>();
     auto timer = loop_->resource<libuv::Timer>();
 
@@ -458,7 +458,7 @@ void Device::listenCallback() {
 
   // Wait for remote side to write sequence number.
   handle->once<libuv::ReadEvent>(
-      [=](const libuv::ReadEvent& event, libuv::TCP& handle) {
+      [=, this](const libuv::ReadEvent& event, libuv::TCP& handle) {
         // Sequence number has been read. Either there is an existing
         // connection callback for this sequence number, or we'll hold
         // on to the handle while we wait for the pair to pass a

--- a/gloo/transport/uv/pair.cc
+++ b/gloo/transport/uv/pair.cc
@@ -554,7 +554,7 @@ void Pair::closeWhileHoldingPairLock() {
           state_, CONNECTING, "Cannot close pair while waiting on connection");
       break;
     case CONNECTED:
-      device_->defer([=] { this->handle_->close(); });
+      device_->defer([=, this] { this->handle_->close(); });
       state_ = CLOSING;
       break;
     case CLOSING:


### PR DESCRIPTION
Summary:
This diff enables compilation warning flags for the directory in question. Further details are in [this workplace post](https://fb.workplace.com/permalink.php?story_fbid=pfbid02XaWNiCVk69r1ghfvDVpujB8Hr9Y61uDvNakxiZFa2jwiPHscVdEQwCBHrmWZSyMRl&id=100051201402394).

This is a low-risk diff. There are **no run-time effects** and the diff has already been observed to compile locally. **If the code compiles, it work; test errors are spurious.**

Differential Revision: D87405440


