### PR TITLE
Add missing header inclusion

### DIFF
--- a/gloo/test/main.cc
+++ b/gloo/test/main.cc
@@ -10,6 +10,7 @@
 
 // One-time init to use EPIPE errors instead of SIGPIPE
 #ifndef _WIN32
+#include <signal.h>
 namespace {
 struct Initializer {
   Initializer() {


### PR DESCRIPTION
This PR adds `signal.h` to main test file.