### PR TITLE
Add setThreadName helper and name all gloo threads

### DIFF
--- a/gloo/benchmark/runner.cc
+++ b/gloo/benchmark/runner.cc
@@ -16,6 +16,7 @@
 #include "gloo/broadcast_one_to_all.h"
 #include "gloo/common/common.h"
 #include "gloo/common/logging.h"
+#include "gloo/common/utils.h"
 #include "gloo/rendezvous/context.h"
 #include "gloo/rendezvous/file_store.h"
 #include "gloo/rendezvous/prefix_store.h"
@@ -80,22 +81,24 @@ Runner::Runner(const options& options) : options_(options) {
   if (options_.transport == "tls") {
     if (options_.tcpDevice.empty()) {
       transport::tcp::attr attr;
-      transportDevices_.push_back(transport::tcp::tls::CreateDevice(
-          attr,
-          options_.pkey,
-          options_.cert,
-          options_.caFile,
-          options_.caPath));
+      transportDevices_.push_back(
+          transport::tcp::tls::CreateDevice(
+              attr,
+              options_.pkey,
+              options_.cert,
+              options_.caFile,
+              options_.caPath));
     } else {
       for (const auto& name : options_.tcpDevice) {
         transport::tcp::attr attr;
         attr.iface = name;
-        transportDevices_.push_back(transport::tcp::tls::CreateDevice(
-            attr,
-            options_.pkey,
-            options_.cert,
-            options_.caFile,
-            options_.caPath));
+        transportDevices_.push_back(
+            transport::tcp::tls::CreateDevice(
+                attr,
+                options_.pkey,
+                options_.cert,
+                options_.caFile,
+                options_.caPath));
       }
     }
   }
@@ -625,6 +628,7 @@ void RunnerThread::run(RunnerJob* job) {
 }
 
 void RunnerThread::spawn() {
+  setThreadName("gloo_bench");
   std::unique_lock<std::mutex> lock(mutex_);
   while (!stop_) {
     while (job_ == nullptr) {

--- a/gloo/common/utils.h
+++ b/gloo/common/utils.h
@@ -14,6 +14,10 @@ namespace gloo {
 
 std::string getHostname();
 
+// Set the name of the current thread for debugging purposes.
+// The name should be 15 characters or less (will be truncated if longer).
+void setThreadName(const std::string& name);
+
 bool useRankAsSeqNumber();
 
 bool isStoreExtendedApiEnabled();

--- a/gloo/transport/ibverbs/device.cc
+++ b/gloo/transport/ibverbs/device.cc
@@ -17,6 +17,7 @@
 #include "gloo/common/error.h"
 #include "gloo/common/linux.h"
 #include "gloo/common/logging.h"
+#include "gloo/common/utils.h"
 #include "gloo/transport/ibverbs/context.h"
 #include "gloo/transport/ibverbs/pair.h"
 
@@ -193,6 +194,7 @@ std::shared_ptr<transport::Context> Device::createContext(int rank, int size) {
 }
 
 void Device::loop() {
+  setThreadName("gloo_ib_loop");
   int rv;
 
   auto flags = fcntl(comp_channel_->fd, F_GETFL);

--- a/gloo/transport/tcp/loop.cc
+++ b/gloo/transport/tcp/loop.cc
@@ -16,6 +16,7 @@
 
 #include <gloo/common/error.h>
 #include <gloo/common/logging.h>
+#include <gloo/common/utils.h>
 
 #if defined(__SANITIZE_THREAD__)
 #define TSAN_ENABLED
@@ -187,6 +188,7 @@ void Loop::defer(std::function<void()> fn) {
 }
 
 void Loop::run() {
+  setThreadName("gloo_tcp_loop");
   std::array<struct epoll_event, capacity_> events;
   int nfds;
 

--- a/gloo/transport/uv/device.cc
+++ b/gloo/transport/uv/device.cc
@@ -23,6 +23,7 @@
 #include <gloo/common/win.h> // @manual
 #endif
 #include <gloo/common/logging.h>
+#include <gloo/common/utils.h>
 #include <gloo/transport/uv/common.h>
 #include <gloo/transport/uv/context.h>
 #include <gloo/transport/uv/libuv.h>
@@ -208,7 +209,10 @@ Device::Device(const struct attr& attr) : attr_(attr) {
   addr_ = Address(listener_->sockname());
 
   // Run uv_run on private thread.
-  thread_.reset(new std::thread([this] { loop_->run(); }));
+  thread_.reset(new std::thread([this] {
+    setThreadName("gloo_uv_loop");
+    loop_->run();
+  }));
 }
 
 Device::~Device() {


### PR DESCRIPTION
Summary:
Add a `setThreadName()` helper function to set thread names for debugging purposes, and use it to name all threads created in the gloo library:

- `gloo_tcp_loop` - TCP transport epoll event loop
- `gloo_uv_loop` - libuv event loop  
- `gloo_ib_loop` - InfiniBand completion queue handler
- `gloo_bench` - Benchmark runner thread
- `gloo_tls_loop` - TLS event loop

Thread names are limited to 15 characters on Linux (plus null terminator) and are set using `pthread_setname_np()`. On platforms where this is not available (Windows), the function is a no-op.

This makes it easier to identify gloo threads when debugging with tools like `top`, `htop`, or `gdb`.

---
> Generated by [Confucius Code Assist (CCA)](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Confucius Session](https://www.internalfb.com/confucius?host=devvm5553.cco0.facebook.com&port=8088&tab=Chat&session_id=190f4fa8-edb9-11f0-ba82-4857dd1ee1b5&entry_name=Code+Assist), [Trace](https://www.internalfb.com/confucius?session_id=190f4fa8-edb9-11f0-ba82-4857dd1ee1b5&tab=Trace)

Reviewed By: fduwjj

Differential Revision: D90423385


