### PR TITLE
ci: bump linter to clang-format 21.1.2

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -24,8 +24,9 @@ jobs:
           # Full git history is needed to get a proper list of changed files
           # within `super-linter`
           fetch-depth: 0
+          persist-credentials: false
       - name: Super-linter
-        uses: super-linter/super-linter@v7.3.0 # x-release-please-version
+        uses: super-linter/super-linter@d5b0a2ab116623730dd094f15ddc1b6b25bf7b99 # v8.3.2
         env:
           LINTER_RULES_PATH: .github/config/lint
           # To report GitHub Actions status checks


### PR DESCRIPTION
This bumps the linter to better match internal fbcode linters.

Test plan:

CI