### PR TITLE
Fix -Wnontrivial-memcall error in AllreduceLocal

### DIFF
--- a/gloo/allreduce_local.cc
+++ b/gloo/allreduce_local.cc
@@ -32,7 +32,7 @@ void AllreduceLocal<T>::run() {
   }
   // Broadcast ptrs_[0]
   for (int i = 1; i < ptrs_.size(); i++) {
-    memcpy(ptrs_[i], ptrs_[0], bytes_);
+    memcpy((void*)ptrs_[i], (const void*)ptrs_[0], bytes_);
   }
 }
 


### PR DESCRIPTION
Summary: Add explicit void* casts to memcpy arguments to fix -Wnontrivial-memcall error when instantiating AllreduceLocal with float16 type.

Differential Revision:
D90555676

Privacy Context Container: L1196524


