### PR TITLE
Fix handling of cudaDeviceEnablePeerAccess return value

### DIFF
--- a/gloo/cuda_collectives_native.h
+++ b/gloo/cuda_collectives_native.h
@@ -83,10 +83,8 @@ class CudaLocalNativeReduce : public LocalOp<T> {
 
         // Enable peer access for devA to memory on devB
         CUDA_CHECK(cudaSetDevice(devA));
-        (void)cudaDeviceEnablePeerAccess(devB, 0);
-
-        // Use cudaGetLastError so that any error is cleared.
-        auto err = cudaGetLastError();
+        cudaError_t err = cudaDeviceEnablePeerAccess(devB, 0);
+        // peer access already enabled
         if (err != cudaErrorPeerAccessAlreadyEnabled) {
           CUDA_CHECK(err);
         }
@@ -196,10 +194,8 @@ class CudaLocalNativeBroadcast : public LocalOp<T> {
 
         // Enable peer access for devA to memory on devB
         CUDA_CHECK(cudaSetDevice(devA));
-        (void)cudaDeviceEnablePeerAccess(devB, 0);
-
-        // Use cudaGetLastError so that any error is cleared.
-        auto err = cudaGetLastError();
+        cudaError_t err = cudaDeviceEnablePeerAccess(devB, 0);
+        // peer access already enabled
         if (err != cudaErrorPeerAccessAlreadyEnabled) {
           CUDA_CHECK(err);
         }


### PR DESCRIPTION
### Problem
When building PyTorch on AMD ROCm the build reported a warning for hipDeviceEnablePeerAccess().
```
/home/anvishwa/src/pytorch/build/third_party/gloo/hip/gloo/hip_collectives_native.h:86:9: warning: ignoring return value of type 'hipError_t' declared with 'nodiscard' attribute [-Wunused-value]
86 |         hipDeviceEnablePeerAccess(devB, 0);
```

### Summary
Handle the return value of `cudaDeviceEnablePeerAccess` correctly instead of using `cudaGetLastError()`. 
`cudaDeviceEnablePeerAccess` is a synchronous host API. Its return value already reflects the call result, so `cudaGetLastError()` is unnecessary and can return stale errors from earlier async work.

### Signature
***
__host__​[cudaError_t](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1gf599e5b8b829ce7db0f5216928f6ecb6) [cudaDeviceEnablePeerAccess](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__PEER.html#group__CUDART__PEER_1g2b0adabf90db37e5cfddc92cbb2589f3) ( int  peerDevice, unsigned int  flags )
Enables direct access to memory allocations on a peer device.
***

The change is nominal and resolves the build warning while keeping the same behavior.
