### PR TITLE
Fix [[nodiscard]] build errors and BUCK deps across comms, gloo, caffe2

### DIFF
--- a/gloo/cuda_collectives_native.h
+++ b/gloo/cuda_collectives_native.h
@@ -83,7 +83,7 @@ class CudaLocalNativeReduce : public LocalOp<T> {
 
         // Enable peer access for devA to memory on devB
         CUDA_CHECK(cudaSetDevice(devA));
-        cudaDeviceEnablePeerAccess(devB, 0);
+        (void)cudaDeviceEnablePeerAccess(devB, 0);
 
         // Use cudaGetLastError so that any error is cleared.
         auto err = cudaGetLastError();
@@ -196,7 +196,7 @@ class CudaLocalNativeBroadcast : public LocalOp<T> {
 
         // Enable peer access for devA to memory on devB
         CUDA_CHECK(cudaSetDevice(devA));
-        cudaDeviceEnablePeerAccess(devB, 0);
+        (void)cudaDeviceEnablePeerAccess(devB, 0);
 
         // Use cudaGetLastError so that any error is cleared.
         auto err = cudaGetLastError();


### PR DESCRIPTION
Summary:
ROCm 7.0+ HIP headers annotate API functions (hipStreamDestroy,
hipMemcpyAsync, hipStreamSynchronize, hipSetDevice, hipGetDevice, hipFree,
hipHostUnregister, hipDeviceEnablePeerAccess, cuGetErrorString) with
[[nodiscard]]. Combined with -Werror, this causes build failures wherever
return values are discarded.

Originally discovered building with ROCm 7.2 headers, but confirmed to
also affect ROCm 7.0 builds (reported independently by yvliu and hqguo).
The [[nodiscard]] attribute is present in both ROCm 7.0 and 7.2 HIP
headers — the fix is the same for both versions.

Changes:
- Add (void) casts to suppress [[nodiscard]] warnings across comms/
  (tcp_devmem, ctran, rcclx), gloo/, and caffe2/ (nativert) — 12 C++ files
- Fix BUCK dependency issues in comms/tcp_devmem/nccl (replace devmgr-client
  with common:common) and comms/tcp_devmem/unpack (explicit glog dep path)
  that surface when building these targets under ROCm constraints

The (void) casts are no-ops on CUDA and older ROCm — safe to land
regardless of ROCm version.

Reviewed By: bbeckca

Differential Revision: D93759269


