### PR TITLE
Fix [[nodiscard]] cudaDeviceEnablePeerAccess warning in gloo

### DIFF
--- a/gloo/cuda_collectives_native.h
+++ b/gloo/cuda_collectives_native.h
@@ -83,7 +83,7 @@ class CudaLocalNativeReduce : public LocalOp<T> {
 
         // Enable peer access for devA to memory on devB
         CUDA_CHECK(cudaSetDevice(devA));
-        cudaDeviceEnablePeerAccess(devB, 0);
+        (void)cudaDeviceEnablePeerAccess(devB, 0);
 
         // Use cudaGetLastError so that any error is cleared.
         auto err = cudaGetLastError();
@@ -196,7 +196,7 @@ class CudaLocalNativeBroadcast : public LocalOp<T> {
 
         // Enable peer access for devA to memory on devB
         CUDA_CHECK(cudaSetDevice(devA));
-        cudaDeviceEnablePeerAccess(devB, 0);
+        (void)cudaDeviceEnablePeerAccess(devB, 0);
 
         // Use cudaGetLastError so that any error is cleared.
         auto err = cudaGetLastError();


### PR DESCRIPTION
Summary:
ROCm 7.0+ HIP headers annotate cudaDeviceEnablePeerAccess with
[[nodiscard]]. Add (void) cast to suppress the warning. The cast is a
no-op on CUDA and older ROCm.

ghstack-source-id: 0

Reviewed By: bbeckca

Differential Revision: D96004741


