### PR TITLE
Fix address family mismatch by reusing bound socket (#503)

### DIFF
--- a/gloo/transport/tcp/attr.h
+++ b/gloo/transport/tcp/attr.h
@@ -31,6 +31,12 @@ struct attr {
   int ai_protocol;
   struct sockaddr_storage ai_addr;
   int ai_addrlen;
+
+  // Pre-bound socket file descriptor. When set to a valid fd (>= 0),
+  // the Listener will adopt this socket instead of creating a new one
+  // and binding again. This avoids EADDRINUSE races between the test
+  // bind in address resolution and the actual listener bind.
+  int ai_fd = -1;
 };
 
 } // namespace tcp

--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -104,6 +104,9 @@ static void lookupAddrForHostname(struct attr& attr) {
       continue;
     }
 
+    int on = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+
     bind_rv = bind(fd, rp->ai_addr, rp->ai_addrlen);
     if (bind_rv == -1) {
       bind_errno = errno;
@@ -117,7 +120,7 @@ static void lookupAddrForHostname(struct attr& attr) {
     attr.ai_protocol = rp->ai_protocol;
     memcpy(&attr.ai_addr, rp->ai_addr, rp->ai_addrlen);
     attr.ai_addrlen = rp->ai_addrlen;
-    close(fd);
+    attr.ai_fd = fd;
     break;
   }
 

--- a/gloo/transport/tcp/listener.cc
+++ b/gloo/transport/tcp/listener.cc
@@ -23,9 +23,14 @@ namespace tcp {
 
 Listener::Listener(std::shared_ptr<Loop> loop, const attr& attr)
     : loop_(std::move(loop)) {
-  listener_ = Socket::createForFamily(attr.ai_addr.ss_family);
-  listener_->reuseAddr(true);
-  listener_->bind(attr.ai_addr);
+  if (attr.ai_fd >= 0) {
+    listener_ = std::make_shared<Socket>(attr.ai_fd);
+    listener_->block(false);
+  } else {
+    listener_ = Socket::createForFamily(attr.ai_addr.ss_family);
+    listener_->reuseAddr(true);
+    listener_->bind(attr.ai_addr);
+  }
   listener_->listen(kBacklog);
   addr_ = listener_->sockName();
   useRankAsSeqNumber_ = useRankAsSeqNumber();


### PR DESCRIPTION
Summary:

Fix AF_INET vs AF_INET6 address family mismatch errors during Gloo TCP connection establishment. The issue occurred because address resolution would bind a test socket to determine the local address, then close it and create a new socket in the Listener, which could bind to a different address family. Now preserve the bound socket file descriptor through the attr structure and reuse it in the Listener, ensuring consistent address family between resolution and listening.

---
AI generated Summary & Test Plan from DEV179294118

Reviewed By: kausv

Differential Revision: D101060657


