### PR TITLE
Fix flaky timing assertion in gloo transport multiproc tests

### DIFF
--- a/gloo/test/transport_test.cc
+++ b/gloo/test/transport_test.cc
@@ -98,7 +98,7 @@ TEST_P(TransportMultiProcTest, IoErrors) {
   wait();
   const auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::high_resolution_clock::now() - start);
-  ASSERT_LT(delta.count(), kMultiProcTimeout.count() * 2);
+  ASSERT_LT(delta.count(), kMultiProcTimeout.count() * 4);
 
   for (auto i = 0; i < processCount; i++) {
     if (i != 0) {
@@ -199,7 +199,7 @@ TEST_P(TransportMultiProcTest, UnboundIoErrors) {
   wait();
   const auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::high_resolution_clock::now() - start);
-  ASSERT_LT(delta.count(), kMultiProcTimeout.count() * 2);
+  ASSERT_LT(delta.count(), kMultiProcTimeout.count() * 4);
 
   for (auto i = 0; i < processCount; i++) {
     if (i != 0) {


### PR DESCRIPTION
Summary:
The IoErrors and UnboundIoErrors tests assert that error propagation after SIGKILL completes within `kMultiProcTimeout * 2` (6s). On loaded CI machines, TCP error detection and process scheduling delays can push wall-clock time well beyond this limit (observed ~10.6s), causing spurious failures. Relax the multiplier from 2x to 4x to accommodate CI variability while still catching genuine hangs.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: testing_frameworks

Differential Revision: D102326105


