### PR TITLE
Fix preprocessor guard in `gloo/cuda.h` for HIP/ROCm builds (#507)

### DIFF
--- a/gloo/cuda.h
+++ b/gloo/cuda.h
@@ -20,8 +20,8 @@
 #include "gloo/config.h"
 
 // Check that configuration header was properly generated
-#if !GLOO_USE_CUDA
-#error "Expected GLOO_USE_CUDA to be defined"
+#if !GLOO_USE_CUDA && !GLOO_USE_ROCM
+#error "Expected GLOO_USE_CUDA or GLOO_USE_ROCM to be set"
 #endif
 
 namespace gloo {


### PR DESCRIPTION
Summary:

https://github.com/pytorch/gloo/issues/506

Change `#if !GLOO_USE_CUDA` to `#if !GLOO_USE_CUDA && !GLOO_USE_ROCM` so the guard checks whether the either macro is defined and non-zero. The old form fails when `GLOO_USE_CUDA` is defined to `0` (e.g., in a ROCm-only CMake build via `#cmakedefine01`), because `!0` evaluates to true and triggers the `#error` even though the configuration header was properly generated.

Reviewed By: d4l3k

Differential Revision: D106397943


