### PR TITLE
fix GCC 15 build by including <cstdint>

### DIFF
--- a/gloo/transport/tcp/device.cc
+++ b/gloo/transport/tcp/device.cc
@@ -7,7 +7,7 @@
  */
 
 #include "gloo/transport/tcp/device.h"
-
+#include <array>
 #include <ifaddrs.h>
 #include <netdb.h>
 #include <netinet/in.h>

--- a/gloo/types.h
+++ b/gloo/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 
 #ifdef __CUDA_ARCH__


### PR DESCRIPTION
## Summary

本 PR 修复 GCC 15 下的构建问题，在 `gloo/types.h` 中补充直接依赖的 `<cstdint>` 头文件。

## Changes

- 在 `gloo/types.h` 中添加 `#include <cstdint>`。

## background

`gloo/types.h` 使用了固定宽度整数类型，但此前没有直接包含 `<cstdint>`。GCC 15 下该依赖不再能稳定通过其他头文件间接获得，因此会暴露缺失头文件导致的编译失败。

相关链接：
* https://gcc.gnu.org/cgit/gcc/commit/?id=3a817a4a5a6d94da9127af3be9f84a74e3076ee2
* https://gcc.gnu.org/pipermail/gcc-cvs/2024-August/407124.html
* https://github.com/pytorch/gloo/pull/452