### PR TITLE
gloo/tcp: fix size_t overflow in recv bounds check (relative write-what-where)

### DIFF
--- a/gloo/test/CMakeLists.txt
+++ b/gloo/test/CMakeLists.txt
@@ -25,6 +25,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     "${CMAKE_CURRENT_SOURCE_DIR}/multiproc_test.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/transport_test.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/tcp_test.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/pair_test.cc"
     )
   list(APPEND GLOO_TEST_LIBRARIES rt)
 endif()

--- a/gloo/test/pair_test.cc
+++ b/gloo/test/pair_test.cc
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2024-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "gloo/test/base_test.h"
+
+#include "gloo/common/logging.h"
+
+#if GLOO_HAVE_TRANSPORT_TCP
+
+namespace gloo {
+namespace test {
+namespace {
+
+// Test parameterization (transport).
+using Param = Transport;
+
+// Test fixture.
+class PairTest : public BaseTest,
+                 public ::testing::WithParamInterface<Param> {};
+
+// Regression test for the size_t overflow in tcp::Pair::prepareRead.
+//
+// A SEND_BUFFER preamble carries `roffset` and `length` as size_t values read
+// directly off the socket. The receive bounds check used to be
+// `roffset + length <= size_`, where the addition wraps modulo 2^64. A
+// malicious peer could pick e.g. roffset = (size_t)-8 and length = 8 so the sum
+// wraps to 0 and passes the check, while the payload gets written at
+// `ptr_ + roffset` -- an out-of-bounds write relative to the registered buffer.
+//
+// The receiver must reject such a preamble instead of performing the write.
+TEST_P(PairTest, RecvBufferRejectsRoffsetLengthOverflow) {
+  const auto transport = GetParam();
+
+  spawn(transport, 2, [&](std::shared_ptr<Context> context) {
+    constexpr size_t kSize = 64;
+    std::vector<char> data(kSize);
+
+    const int peer = (context->rank + 1) % 2;
+    auto& pair = context->getPair(peer);
+
+    // Use synchronous mode so reads happen on this thread; the resulting
+    // exception can then be observed directly. In async mode the read runs on
+    // the device loop thread where it cannot be caught by the test.
+    pair->setSync(true, false);
+
+    if (context->rank == 0) {
+      // Receiver: register a buffer and expect the malicious send to be
+      // rejected by the overflow-safe bounds check.
+      auto recvBuffer = pair->createRecvBuffer(0, data.data(), data.size());
+      EXPECT_THROW(recvBuffer->waitRecv(), ::gloo::EnforceNotMet);
+    } else {
+      // Sender: emulate a malicious peer. The sender-side check only validates
+      // `offset + length` against the local buffer, so `roffset` (the remote
+      // offset) passes through onto the wire unchecked.
+      auto sendBuffer = pair->createSendBuffer(0, data.data(), data.size());
+      const size_t length = 8;
+      // roffset + length wraps to 0: (2^64 - 8) + 8 == 0, which is <= size_.
+      const size_t roffset = ~static_cast<size_t>(0) - (length - 1);
+      sendBuffer->send(/*offset=*/0, length, roffset);
+      sendBuffer->waitSend();
+    }
+  });
+}
+
+// Positive control: a valid (non-overflowing) roffset must still be honored,
+// i.e. the payload lands at `ptr_ + roffset` in the receive buffer. This guards
+// against the bounds check being made overly strict.
+TEST_P(PairTest, RecvBufferHonorsValidRoffset) {
+  const auto transport = GetParam();
+
+  spawn(transport, 2, [&](std::shared_ptr<Context> context) {
+    constexpr size_t kSize = 64;
+    constexpr size_t kLength = 8;
+    constexpr size_t kRoffset = 16;
+    std::vector<char> data(kSize, 0);
+
+    const int peer = (context->rank + 1) % 2;
+    auto& pair = context->getPair(peer);
+    pair->setSync(true, false);
+
+    if (context->rank == 0) {
+      auto recvBuffer = pair->createRecvBuffer(0, data.data(), data.size());
+      recvBuffer->waitRecv();
+
+      // Payload must land exactly in [kRoffset, kRoffset + kLength).
+      std::vector<char> expected(kSize, 0);
+      for (size_t i = 0; i < kLength; i++) {
+        expected[kRoffset + i] = static_cast<char>(i + 1);
+      }
+      EXPECT_EQ(data, expected);
+    } else {
+      for (size_t i = 0; i < kLength; i++) {
+        data[i] = static_cast<char>(i + 1);
+      }
+      auto sendBuffer = pair->createSendBuffer(0, data.data(), data.size());
+      sendBuffer->send(/*offset=*/0, kLength, kRoffset);
+      sendBuffer->waitSend();
+    }
+  });
+}
+
+INSTANTIATE_TEST_CASE_P(
+    PairTests,
+    PairTest,
+    ::testing::Values(
+        Transport::TCP
+#if GLOO_HAVE_TRANSPORT_TCP_TLS
+        ,
+        Transport::TCP_TLS
+#endif
+        ));
+
+} // namespace
+} // namespace test
+} // namespace gloo
+
+#endif // GLOO_HAVE_TRANSPORT_TCP

--- a/gloo/transport/tcp/pair.cc
+++ b/gloo/transport/tcp/pair.cc
@@ -419,11 +419,19 @@ ssize_t Pair::prepareRead(
       }
     }
 
+    // Bytes read must be in bounds for target buffer. roffset and length are
+    // read directly from the remote peer, so the bounds check must not
+    // overflow: evaluating "roffset + length" is a size_t addition that can
+    // wrap around 2^64, letting an out-of-bounds (roffset, length) pair pass
+    // the check and yielding an arbitrary write at "ptr_ + roffset". Validate
+    // each term against the buffer size independently so the sum can't wrap.
+    // This is checked before computing iov_base to avoid forming an
+    // out-of-bounds pointer.
+    GLOO_ENFORCE_LE(op.preamble.roffset, op.buf->size_);
+    GLOO_ENFORCE_LE(op.preamble.length, op.buf->size_ - op.preamble.roffset);
+
     iov.iov_base = ((char*)op.buf->ptr_) + offset + op.preamble.roffset;
     iov.iov_len = op.preamble.length - offset;
-
-    // Bytes read must be in bounds for target buffer
-    GLOO_ENFORCE_LE(op.preamble.roffset + op.preamble.length, op.buf->size_);
     return iov.iov_len;
   }
 


### PR DESCRIPTION
Summary:
`tcp::Pair::prepareRead` validated incoming `SEND_BUFFER` payloads with `GLOO_ENFORCE_LE(op.preamble.roffset + op.preamble.length, op.buf->size_)`, where `roffset` and `length` are `size_t` fields read directly off the socket (`Op::preamble` in `pair.h`). The addition wraps modulo 2^64, so a malicious peer can pick e.g. `roffset = (size_t)-8` and `length = 8`: the sum wraps to `0`, passes the check, and `recv()` then writes attacker-controlled bytes at `((char*)op.buf->ptr_) + roffset` (= `ptr_ - 8`). Varying `(roffset, length)` pairs whose sum wraps to `<= size_` yields a relative write-what-where primitive at an arbitrary 64-bit offset from a registered buffer, with fully attacker-controlled content. Gloo `SECURITY.md` puts network-exploitable RCE in scope.

This rewrites the check to validate each term independently so the sum cannot wrap: `roffset <= size_` and `length <= size_ - roffset`. This mirrors the existing overflow-safe pattern already used in `Pair::send`/`recv`/`tryRecv`. The check is also moved ahead of the `iov_base` computation so an out-of-bounds pointer is never formed — UBSan flagged the old `ptr_ + roffset` arithmetic itself as `pointer-overflow`, independent of the enforce.

The same `prepareRead` is inherited by the TLS transport (`tcp::tls::Pair`), so both TCP and TCP+TLS are fixed by this change.

Differential Revision: D108082771


